### PR TITLE
Null pointer protection

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@
 
 [[constraint]]
   name = "github.com/republicprotocol/republic-go"
-  branch = "master"
+  branch = "null-pointer-protection"
 
 # Temporary fix https://github.com/golang/dep/issues/1799
 [[override]]

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -68,9 +68,6 @@ func main() {
 		log.Fatalf("cannot get multi-address: %v", err)
 	}
 
-	if config.Ethereum == nil {
-		log.Fatalf("cannot parse Ethereum config")
-	}
 	conn, err := contract.Connect(config.Ethereum)
 	if err != nil {
 		log.Fatalf("cannot connect to ethereum: %v", err)

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -107,15 +107,16 @@ func main() {
 				logger.Network(logger.LevelError, "cannot store null bootstrap address from config file")
 				continue
 			}
-			multi, err := store.SwarmMultiAddressStore().MultiAddress(multiAddr.Address())
-			if err != nil && err != swarm.ErrMultiAddressNotFound {
+			_, err := store.SwarmMultiAddressStore().MultiAddress(multiAddr.Address())
+			if err == nil {
+				// Only add bootstrap multi-addresses that are not already in the store.
+				continue
+			}
+			if err != swarm.ErrMultiAddressNotFound {
 				logger.Network(logger.LevelError, fmt.Sprintf("cannot get bootstrap multi-address from store: %v", err))
 				continue
 			}
-			if err == nil {
-				multiAddr.Nonce = multi.Nonce
-				multiAddr.Signature = multi.Signature
-			}
+
 			if err := store.SwarmMultiAddressStore().InsertMultiAddress(multiAddr); err != nil {
 				logger.Network(logger.LevelError, fmt.Sprintf("cannot store bootstrap multiaddress in store: %v", err))
 			}

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -103,8 +103,8 @@ func main() {
 	go func() {
 		// Add bootstrap nodes in the storer or load from the file .
 		for _, multiAddr := range config.BootstrapMultiAddresses {
-			if multiAddr.IsEmpty() {
-				logger.Network(logger.LevelError, fmt.Sprintf("cannot store null bootstrap address from config file: %v", err))
+			if multiAddr.IsNil() {
+				logger.Network(logger.LevelError, "cannot store null bootstrap address from config file")
 				continue
 			}
 			multi, err := store.SwarmMultiAddressStore().MultiAddress(multiAddr.Address())

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -39,9 +39,24 @@ var ErrInvalidNumberOfOrderFragments = errors.New("invalid number of order fragm
 // of an invalid length.
 var ErrInvalidOrderFragmentMapping = errors.New("invalid order fragment mappings")
 
-// ErrInvalidOrderFragment is returned when an invalid orderFragment is provided
+// ErrOrderFragmentIsNil is returned when a nil orderFragment is provided
 // upon verification.
-var ErrInvalidOrderFragment = errors.New("invalid order fragment")
+var ErrOrderFragmentIsNil = errors.New("order fragment is nil")
+
+// ErrMultiAddressIsNil is returned when a nil multi-address is detected.
+var ErrMultiAddressIsNil = errors.New("multi-address is nil")
+
+// ErrEpochIsNil is returned when a nil epoch is detected.
+var ErrEpochIsNil = errors.New("epoch is nil")
+
+// ErrOpenOrderRequestIsNil is returned when a nil OpenOrderRequest is detected.
+var ErrOpenOrderRequestIsNil = errors.New("OpenOrderRequest is nil")
+
+// ErrCancelOrderRequestIsNil is returned when a nil CancelOrderRequest is detected.
+var ErrCancelOrderRequestIsNil = errors.New("CancelOrderRequest is nil")
+
+// ErrOrderFragmentMappingRequestIsNil is returned when a nil OrderFragmentMappingRequest is detected.
+var ErrOrderFragmentMappingRequestIsNil = errors.New("OrderFragmentMappingRequest is nil")
 
 // ErrInvalidEpochDepth is returned when an invalid epoch depth is provided
 // upon verification.
@@ -135,8 +150,8 @@ func (ingress *ingress) Sync(done <-chan struct{}) <-chan error {
 		close(errs)
 		return errs
 	}
-	if epoch.IsEmpty() {
-		errs <- fmt.Errorf("cannot sync: null epoch")
+	if epoch.IsNil() {
+		errs <- ErrEpochIsNil
 		close(errs)
 		return errs
 	}
@@ -178,7 +193,7 @@ func (ingress *ingress) Sync(done <-chan struct{}) <-chan error {
 						}
 					}
 
-					if nextEpoch.IsEmpty() {
+					if nextEpoch.IsNil() {
 						continue
 					}
 
@@ -322,8 +337,8 @@ func (ingress *ingress) processRequestQueue(done <-chan struct{}, errs chan<- er
 }
 
 func (ingress *ingress) processOpenOrderRequest(req OpenOrderRequest, done <-chan struct{}, errs chan<- error) {
-	if req.IsEmpty() {
-		errs <- fmt.Errorf("[error] (open) invalid OpenOrderRequest")
+	if req.IsNil() {
+		errs <- ErrOpenOrderRequestIsNil
 		return
 	}
 	var err error
@@ -341,8 +356,8 @@ func (ingress *ingress) processOpenOrderRequest(req OpenOrderRequest, done <-cha
 }
 
 func (ingress *ingress) processCancelOrderRequest(req CancelOrderRequest, done <-chan struct{}, errs chan<- error) {
-	if req.IsEmpty() {
-		errs <- fmt.Errorf("[error] (cancel) invalid CancelOrderRequest")
+	if req.IsNil() {
+		errs <- ErrCancelOrderRequestIsNil
 		return
 	}
 	if err := ingress.contract.CancelOrder(req.signature, req.orderID); err != nil {
@@ -354,8 +369,8 @@ func (ingress *ingress) processCancelOrderRequest(req CancelOrderRequest, done <
 }
 
 func (ingress *ingress) processOpenOrderFragmentMappingRequest(req OpenOrderFragmentMappingRequest, done <-chan struct{}, errs chan<- error) {
-	if req.IsEmpty() {
-		errs <- fmt.Errorf("[error] (open) invalid OpenOrderFragmentMappingRequest")
+	if req.IsNil() {
+		errs <- ErrOrderFragmentMappingRequestIsNil
 		return
 	}
 	ingress.podsMu.RLock()
@@ -426,7 +441,7 @@ func (ingress *ingress) sendOrderFragmentsToPod(pod registry.Pod, orderFragments
 				errs <- fmt.Errorf("no fragment found at index %v", i)
 				return
 			}
-			if orderFragment.IsEmpty() || orderFragment.EncryptedFragment.IsEmpty() {
+			if orderFragment.IsNil() || orderFragment.EncryptedFragment.IsNil() {
 				errs <- fmt.Errorf("invalid order fragment found at index %v", i)
 				return
 			}
@@ -448,8 +463,8 @@ func (ingress *ingress) sendOrderFragmentsToPod(pod registry.Pod, orderFragments
 				return
 			}
 
-			if darknodeMultiAddr.IsEmpty() {
-				errs <- fmt.Errorf("invalid darknode multi-address detected")
+			if darknodeMultiAddr.IsNil() {
+				errs <- ErrMultiAddressIsNil
 				return
 			}
 
@@ -528,8 +543,8 @@ func (ingress *ingress) verifyOrderFragmentMapping(orderFragmentMapping OrderFra
 		// Ensure order fragment Epoch depth matches up with value provided as
 		// parameter.
 		for _, orderFragment := range orderFragments {
-			if orderFragment.IsEmpty() {
-				return ErrInvalidOrderFragment
+			if orderFragment.IsNil() {
+				return ErrOrderFragmentIsNil
 			}
 			if orderFragment.EpochDepth != order.FragmentEpochDepth(orderFragmentEpochDepth) {
 				return ErrInvalidEpochDepth

--- a/ingress/request.go
+++ b/ingress/request.go
@@ -23,8 +23,8 @@ type OpenOrderRequest struct {
 // IsRequest implements the Request interface.
 func (req OpenOrderRequest) IsRequest() {}
 
-// IsEmpty returns true if the OpenOrderRequest contains nil fields
-func (req *OpenOrderRequest) IsEmpty() bool {
+// IsNil returns true if the OpenOrderRequest contains nil fields
+func (req *OpenOrderRequest) IsNil() bool {
 	return req == nil || len(req.signature) != 65 || len(req.orderID) != 32
 }
 
@@ -40,8 +40,8 @@ type OpenOrderFragmentMappingRequest struct {
 // IsRequest implements the Request interface.
 func (req OpenOrderFragmentMappingRequest) IsRequest() {}
 
-// IsEmpty returns true if the OpenOrderFragmentMappingRequest contains nil fields
-func (req *OpenOrderFragmentMappingRequest) IsEmpty() bool {
+// IsNil returns true if the OpenOrderFragmentMappingRequest contains nil fields
+func (req *OpenOrderFragmentMappingRequest) IsNil() bool {
 	return req == nil || len(req.signature) != 65 || len(req.orderID) != 32 || len(req.orderFragmentMapping) == 0
 }
 
@@ -55,7 +55,7 @@ type CancelOrderRequest struct {
 // IsRequest implements the Request interface.
 func (req CancelOrderRequest) IsRequest() {}
 
-// IsEmpty returns true if the CancelOrderRequest contains nil fields
-func (req *CancelOrderRequest) IsEmpty() bool {
+// IsNil returns true if the CancelOrderRequest contains nil fields
+func (req *CancelOrderRequest) IsNil() bool {
 	return req == nil || len(req.signature) != 65 || len(req.orderID) != 32
 }

--- a/ingress/request.go
+++ b/ingress/request.go
@@ -23,6 +23,11 @@ type OpenOrderRequest struct {
 // IsRequest implements the Request interface.
 func (req OpenOrderRequest) IsRequest() {}
 
+// IsEmpty returns true if the OpenOrderRequest contains nil fields
+func (req *OpenOrderRequest) IsEmpty() bool {
+	return req == nil || len(req.signature) != 65 || len(req.orderID) != 32
+}
+
 // An OpenOrderFragmentMappingRequest is a Request for the Ingress to open an
 // order.Order by forwarding order.Fragments to their respective Darknodes.
 type OpenOrderFragmentMappingRequest struct {
@@ -35,6 +40,11 @@ type OpenOrderFragmentMappingRequest struct {
 // IsRequest implements the Request interface.
 func (req OpenOrderFragmentMappingRequest) IsRequest() {}
 
+// IsEmpty returns true if the OpenOrderFragmentMappingRequest contains nil fields
+func (req *OpenOrderFragmentMappingRequest) IsEmpty() bool {
+	return req == nil || len(req.signature) != 65 || len(req.orderID) != 32 || len(req.orderFragmentMapping) == 0
+}
+
 // A CancelOrderRequest is a Request for the Ingress to cancel an order.Order
 // on the Ethereum blockchain.
 type CancelOrderRequest struct {
@@ -44,3 +54,8 @@ type CancelOrderRequest struct {
 
 // IsRequest implements the Request interface.
 func (req CancelOrderRequest) IsRequest() {}
+
+// IsEmpty returns true if the CancelOrderRequest contains nil fields
+func (req *CancelOrderRequest) IsEmpty() bool {
+	return req == nil || len(req.signature) != 65 || len(req.orderID) != 32
+}


### PR DESCRIPTION
**Description**

Data received from an external source and being sent to dark nodes should be null-checked before being used; preventing crashes due to null-pointer errors. 

**Design**

All ingress `Request` objects must be checked for the presence of null or invalid fields. Furthermore, order fragments must be checks for null fields before sending them to the dark nodes.
