### PR TITLE
Update Ingress for contract upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Dep
 vendor
+
+# Local environment variables
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9.x
+  - 1.10.4
 
 before_install:
   - go get github.com/onsi/gomega

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -244,7 +244,7 @@
 
 [[projects]]
   branch = "contract-upgrades"
-  digest = "1:e2dd36d1d271e481d61fe042aeb0c507947af0b0f287b439ff8c1dd37e57cd49"
+  digest = "1:7c4c23be2b2da0568ab7513e2b41157dcccf1b0a286d94f39ded092dff192d84"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -267,7 +267,7 @@
     "swarm",
   ]
   pruneopts = "T"
-  revision = "2dbe5f1d654d587810e975d12505400c4805d6a6"
+  revision = "24e7e2dbf5f614e26f1b196deb269a177dfac885"
 
 [[projects]]
   digest = "1:602081d2a289d1f76ea90b806b0c61c19038d76504e9005ccb969864dbaee339"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,17 +3,22 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:79b02529d2120af44eaad5f7fee9ff7e003739d469e2c2767008b797d290e9fd"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
+  pruneopts = "T"
   revision = "18b896026201d8e1758468d9c5d5a558c69c5e9b"
 
 [[projects]]
   branch = "master"
+  digest = "1:b9f5e0f033febe59a62d01e78486c0dd9e4afc9ac5d240aee6ce78a927142e8b"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
+  pruneopts = "T"
   revision = "79e00513b1011888b1e675157ab89f527f901cae"
 
 [[projects]]
+  digest = "1:3e892a54552313db9f7eda71126179f4da5c9d15778681c662f0ef44471698ee"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -48,111 +53,141 @@
     "params",
     "rlp",
     "rpc",
-    "trie"
+    "trie",
   ]
+  pruneopts = "T"
   revision = "37685930d953bcbe023f9bc65b135a8d8b8f1488"
   version = "v1.8.12"
 
 [[projects]]
+  digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
   name = "github.com/go-stack/stack"
   packages = ["."]
+  pruneopts = "T"
   revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
   version = "v1.8.0"
 
 [[projects]]
+  digest = "1:a2ecb56e5053d942aafc86738915fb94c9131bac848c543b8b6764365fd69080"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "T"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:6027b20c168728321bd99ad01f35118eded457b01c03e647a84833ab331f2f5b"
   name = "github.com/golang/snappy"
   packages = ["."]
+  pruneopts = "T"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
+  digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "T"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:e73f5b0152105f18bc131fba127d9949305c8693f8a762588a82a48f61756f5f"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "T"
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:6e7f344f0759e7bd98e5d373e3149b5fca4132261c241777a1c8e57176f1fe05"
   name = "github.com/gxed/hashland"
   packages = ["keccakpg"]
+  pruneopts = "T"
   revision = "d9f6b97f8db22dd1e090fd0bbbe98f09cc7dd0a8"
 
 [[projects]]
   branch = "master"
+  digest = "1:cf296baa185baae04a9a7004efee8511d08e2f5f51d4cbe5375da89722d681db"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "T"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
+  digest = "1:8f20c8dd713564fa97299fbcb77d729c6de9c33f3222812a76e6ecfaef80fd61"
   name = "github.com/hpcloud/tail"
   packages = [
     ".",
     "ratelimiter",
     "util",
     "watch",
-    "winfile"
+    "winfile",
   ]
+  pruneopts = "T"
   revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:fa3a7dc0a780fb19838fb96d4e18c0b9a019d9bb618798308d7b6ca48fcb9876"
   name = "github.com/jbenet/go-base58"
   packages = ["."]
+  pruneopts = "T"
   revision = "6237cf65f3a6f7111cd8a42be3590df99a66bc7d"
   version = "1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:130cefe87d7eeefc824978dcb78e35672d4c49a11f25c153fbf0cfd952756fa3"
   name = "github.com/minio/blake2b-simd"
   packages = ["."]
+  pruneopts = "T"
   revision = "3f5f724cb5b182a5c278d6d3d55b40e7f8c2efb4"
 
 [[projects]]
   branch = "master"
+  digest = "1:17e048d1af8833670439d1ad0c92305fc1ad503e5d03f37ee667c0074df0fd03"
   name = "github.com/minio/sha256-simd"
   packages = ["."]
+  pruneopts = "T"
   revision = "ad98a36ba0da87206e3378c556abbfeaeaa98668"
 
 [[projects]]
   branch = "master"
+  digest = "1:9209bb830bd368966f88ce5f6b56b555d7e1925b4474b273038bded54749360e"
   name = "github.com/mr-tron/base58"
   packages = ["base58"]
+  pruneopts = "T"
   revision = "f84df45a6b88974a98d1473e9f0de0eac859a3d9"
 
 [[projects]]
   branch = "master"
+  digest = "1:ec5c1918a5f897bd6f2196846cdfad01ccfb8625bea6f7ea7f686156f402c5ef"
   name = "github.com/multiformats/go-multiaddr"
   packages = ["."]
+  pruneopts = "T"
   revision = "d6ad8896def6b8571037683cffd995e3a87b14fa"
 
 [[projects]]
   branch = "master"
+  digest = "1:d07386c234cc562e20cff8970d0e327bb37ba2e168075e0045d0b0205a0e57be"
   name = "github.com/multiformats/go-multihash"
   packages = ["."]
+  pruneopts = "T"
   revision = "bffb9dfeaca3b66c0accb675d2910407f3615eec"
 
 [[projects]]
+  digest = "1:99ec7b4370b05816679fe9ae77f1f8af4eae3df0abaeef8c3d2d42d86f55f549"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -172,12 +207,14 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types"
+    "types",
   ]
+  pruneopts = "T"
   revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
   version = "v1.6.0"
 
 [[projects]]
+  digest = "1:7343b611a01c3276e8d1bb69b38f94014dbe6bf92df545b069808f7e7531b802"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -191,19 +228,23 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types"
+    "types",
   ]
+  pruneopts = "T"
   revision = "b6ea1ea48f981d0f615a154a45eabb9dd466556d"
   version = "v1.4.1"
 
 [[projects]]
+  digest = "1:361de06aa7ae272616cbe71c3994a654cc6316324e30998e650f7765b20c5b33"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = "T"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
   branch = "contract-upgrades"
+  digest = "1:953626a10c7062190627160f9dcc3106d86206327d4d1d88395d08134fe26c14"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -223,30 +264,38 @@
     "smpc",
     "stackint",
     "stackint/asm",
-    "swarm"
+    "swarm",
   ]
+  pruneopts = "T"
   revision = "da6d5b27dd6ee8c16a4955cf581b25ecb6c71e46"
 
 [[projects]]
+  digest = "1:6afc433cbb471b1d32de92131245fb1f76000c9d88940265df4a512572a51b51"
   name = "github.com/rjeczalik/notify"
   packages = ["."]
+  pruneopts = "T"
   revision = "52ae50d8490436622a8941bd70c3dbe0acdd4bbf"
   version = "v0.9.0"
 
 [[projects]]
+  digest = "1:6cae6970d70fc5fe75bf83c48ee33e9c4c561a62d0b033254bee8dd5942b815a"
   name = "github.com/rs/cors"
   packages = ["."]
+  pruneopts = "T"
   revision = "3fb1b69b103a84de38a19c3c6ec073dd6caa4d3f"
   version = "v1.5.0"
 
 [[projects]]
+  digest = "1:919bb3aa6d9d0b67648c219fa4925312bc3c2872da19e818fa769e9c97a2b643"
   name = "github.com/spaolacci/murmur3"
   packages = ["."]
+  pruneopts = "T"
   revision = "9f5d223c60793748f04a9d5b4b4eacddfc1f755d"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:ee395d0d8c1719b5a1407f34af93953b4763bacb19a8961aba5b6d312824da41"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -260,24 +309,28 @@
     "leveldb/opt",
     "leveldb/storage",
     "leveldb/table",
-    "leveldb/util"
+    "leveldb/util",
   ]
+  pruneopts = "T"
   revision = "ae2bd5eed72d46b28834ec3f60db3a3ebedd8dbd"
 
 [[projects]]
   branch = "master"
+  digest = "1:da29cbeb9d244918393b37243c008ab7128688fb017c966aaf876587c010bcdd"
   name = "golang.org/x/crypto"
   packages = [
     "blake2s",
     "pbkdf2",
     "ripemd160",
     "scrypt",
-    "sha3"
+    "sha3",
   ]
+  pruneopts = "T"
   revision = "614d502a4dac94afa3a6ce146bd1736da82514c6"
 
 [[projects]]
   branch = "master"
+  digest = "1:c96475ce8a4befca406926432f1a9dea8d17c1573fe99c3086055d28e0910bec"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -290,20 +343,24 @@
     "idna",
     "internal/timeseries",
     "trace",
-    "websocket"
+    "websocket",
   ]
+  pruneopts = "T"
   revision = "8a410e7b638dca158bf9e766925842f6651ff828"
 
 [[projects]]
   branch = "master"
+  digest = "1:d031229a87f35e24ec61e28a3e110b32f0bfca3dce8c0c817001a29f4df6e173"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
-    "unix"
+    "unix",
   ]
+  pruneopts = "T"
   revision = "4910a1d54f876d7b22162a85f4d066d3ee649450"
 
 [[projects]]
+  digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -331,28 +388,42 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "T"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:59a73243379bd5412feb268ec3d9ec0c55acb596ce15fdf937ec29ea6dab441f"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = "T"
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+
+[[projects]]
+  branch = "master"
+  digest = "1:854d075b41117dab6ff576f4308da39f8a187de8ccb97debeaf652f99f60dbc3"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk"
+    "internal/fastwalk",
   ]
+  pruneopts = "T"
   revision = "6cd1fcedba52a3e8045a1c96970cec308e4a632c"
 
 [[projects]]
   branch = "master"
+  digest = "1:960f1fa3f12667fe595c15c12523718ed8b1b5428c83d70da54bb014da9a4c1a"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = "T"
   revision = "c66870c02cf823ceb633bcd05be3c7cda29976f4"
 
 [[projects]]
+  digest = "1:a985c4820889930a08c19181d2aeb1c57ab1929bce7a66b781109dd1db8fb433"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -380,51 +451,89 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap"
+    "tap",
   ]
+  pruneopts = "T"
   revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
   version = "v1.14.0"
 
 [[projects]]
+  digest = "1:3ccd10c863188cfe0d936fcfe6a055c95362e43af8e7039e33baade846928e74"
   name = "gopkg.in/fatih/set.v0"
   packages = ["."]
+  pruneopts = "T"
   revision = "57907de300222151a123d29255ed17f5ed43fad3"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:7fc160b460a6fc506b37fcca68332464c3f2cd57b6e3f111f26c5bbfd2d5518e"
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
+  pruneopts = "T"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   source = "https://github.com/fsnotify/fsnotify.git"
   version = "v1.4.7"
 
 [[projects]]
   branch = "v2"
+  digest = "1:dae137be246befa42ce4b48c0feff2c5796b8a5027139a283f31a21173744410"
   name = "gopkg.in/karalabe/cookiejar.v2"
   packages = ["collections/prque"]
+  pruneopts = "T"
   revision = "8dcd6a7f4951f6ff3ee9cbb919a06d8925822e57"
 
 [[projects]]
   branch = "v2"
+  digest = "1:3d3f9391ab615be8655ae0d686a1564f3fec413979bb1aaf018bac1ec1bb1cc7"
   name = "gopkg.in/natefinch/npipe.v2"
   packages = ["."]
+  pruneopts = "T"
   revision = "c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6"
 
 [[projects]]
   branch = "v1"
+  digest = "1:0caa92e17bc0b65a98c63e5bc76a9e844cd5e56493f8fdbb28fad101a16254d9"
   name = "gopkg.in/tomb.v1"
   packages = ["."]
+  pruneopts = "T"
   revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "T"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "518dcc6836ae8df784dc848b334bc75a5ae8ea1285c23bc50d6390345fbd4e23"
+  input-imports = [
+    "github.com/ethereum/go-ethereum",
+    "github.com/ethereum/go-ethereum/accounts/abi",
+    "github.com/ethereum/go-ethereum/accounts/abi/bind",
+    "github.com/ethereum/go-ethereum/common",
+    "github.com/ethereum/go-ethereum/core/types",
+    "github.com/ethereum/go-ethereum/ethclient",
+    "github.com/ethereum/go-ethereum/event",
+    "github.com/ethereum/go-ethereum/rpc",
+    "github.com/gorilla/mux",
+    "github.com/onsi/ginkgo",
+    "github.com/onsi/gomega",
+    "github.com/republicprotocol/republic-go/contract",
+    "github.com/republicprotocol/republic-go/crypto",
+    "github.com/republicprotocol/republic-go/dispatch",
+    "github.com/republicprotocol/republic-go/grpc",
+    "github.com/republicprotocol/republic-go/identity",
+    "github.com/republicprotocol/republic-go/leveldb",
+    "github.com/republicprotocol/republic-go/logger",
+    "github.com/republicprotocol/republic-go/order",
+    "github.com/republicprotocol/republic-go/orderbook",
+    "github.com/republicprotocol/republic-go/registry",
+    "github.com/republicprotocol/republic-go/swarm",
+    "github.com/rs/cors",
+    "golang.org/x/time/rate",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -244,7 +244,7 @@
 
 [[projects]]
   branch = "contract-upgrades"
-  digest = "1:dc463a39ea0802be5bbb3b05ccae389be005b12dc7cf46f238585e9e9f8c12e1"
+  digest = "1:6fd9291e7b2049f22d45b1b594c385d7babba2d79ab6be817d10aa07bdaac696"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -267,7 +267,7 @@
     "swarm",
   ]
   pruneopts = "T"
-  revision = "55a55682278c49feaec49f10678d5d5ecba983ca"
+  revision = "b1bb4a6612d1dcc6911f70e5fd60cb89a984c519"
 
 [[projects]]
   digest = "1:602081d2a289d1f76ea90b806b0c61c19038d76504e9005ccb969864dbaee339"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,19 +3,19 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6ef484844b7d71500256c410601ae369090c47fca5e49383c6a1932c0a8b4a82"
+  digest = "1:fcee9109b202ec83e394090947c53d9a345c7843a8dd33dde5189ad0e75cbf63"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
   pruneopts = "T"
-  revision = "4dd728aa987e9168a1e609e4919921dbfac9bd7f"
+  revision = "c2e37c381520048ad67de8a2ef5c471603282ab7"
 
 [[projects]]
   branch = "master"
-  digest = "1:b9f5e0f033febe59a62d01e78486c0dd9e4afc9ac5d240aee6ce78a927142e8b"
+  digest = "1:f2d4beb3a1f1d5c59ed38864724bb098952c6230a22a226b30b8cb1dcb8daf79"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
   pruneopts = "T"
-  revision = "79e00513b1011888b1e675157ab89f527f901cae"
+  revision = "cff30e1d23fc9e800b2b5b4b41ef1817dda07e9f"
 
 [[projects]]
   digest = "1:3e892a54552313db9f7eda71126179f4da5c9d15778681c662f0ef44471698ee"
@@ -243,8 +243,16 @@
   version = "v1.1"
 
 [[projects]]
-  branch = "contract-upgrades"
-  digest = "1:7c4c23be2b2da0568ab7513e2b41157dcccf1b0a286d94f39ded092dff192d84"
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "nightly"
+  digest = "1:128ef54fe8f6102a53e4e3590c5caee00beab1769de9866124b715c170d8d369"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -267,7 +275,7 @@
     "swarm",
   ]
   pruneopts = "T"
-  revision = "24e7e2dbf5f614e26f1b196deb269a177dfac885"
+  revision = "3fb2a88f5aef50d120102490330f899ea5881144"
 
 [[projects]]
   digest = "1:602081d2a289d1f76ea90b806b0c61c19038d76504e9005ccb969864dbaee339"
@@ -350,14 +358,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9a36b4bcab9e134eca532df4e80927e808f39346d641c686877d41fdbabdd5cf"
+  digest = "1:bfa444982d49ce4ca1360599270a94de12a573ccd3bf04493c79bee09da3170b"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "T"
-  revision = "49385e6e15226593f68b26af201feec29d5bba22"
+  revision = "2b024373dcd9800f0cae693839fac6ede8d64a8c"
 
 [[projects]]
   digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
@@ -404,7 +412,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5e9594b3370fef04a0a16cc65bf7a1bafa026b02bbf767e6e625eb0f075595a6"
+  digest = "1:48881a3e1353058a0aa4c428c1e030e6e082c048610980f5eb2f103732f44a3c"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -412,15 +420,15 @@
     "internal/fastwalk",
   ]
   pruneopts = "T"
-  revision = "4bc20fc7916bc21abba37451a6923cffa9a2cd3f"
+  revision = "7ca132754999accbaa5c1735eda29e7ce0f3bf03"
 
 [[projects]]
   branch = "master"
-  digest = "1:960f1fa3f12667fe595c15c12523718ed8b1b5428c83d70da54bb014da9a4c1a"
+  digest = "1:e43f1cb3f488a0c2be85939c2a594636f60b442a12a196c778bd2d6c9aca3df7"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "T"
-  revision = "c66870c02cf823ceb633bcd05be3c7cda29976f4"
+  revision = "11092d34479b07829b72e10713b159248caf5dad"
 
 [[projects]]
   digest = "1:a985c4820889930a08c19181d2aeb1c57ab1929bce7a66b781109dd1db8fb433"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -271,7 +271,7 @@
 
 [[projects]]
   branch = "nightly"
-  digest = "1:30226079aa00e3bde6305a8beb0eeac4946575d5eba0bae7a7ef883a5347e786"
+  digest = "1:2bd6d6584caa55c4b632d0ba63351abbc5f3905646961b65b640106197f8af8e"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -294,7 +294,7 @@
     "swarm",
   ]
   pruneopts = "T"
-  revision = "94ef5e7d86bf85d8b4c52843c30b61cd2af2fbad"
+  revision = "2c863d7f62cceaf6424fe9ff653e9c11eae11dc6"
 
 [[projects]]
   digest = "1:602081d2a289d1f76ea90b806b0c61c19038d76504e9005ccb969864dbaee339"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,22 +3,17 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6ef484844b7d71500256c410601ae369090c47fca5e49383c6a1932c0a8b4a82"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
-  pruneopts = "T"
   revision = "4dd728aa987e9168a1e609e4919921dbfac9bd7f"
 
 [[projects]]
   branch = "master"
-  digest = "1:b9f5e0f033febe59a62d01e78486c0dd9e4afc9ac5d240aee6ce78a927142e8b"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
-  pruneopts = "T"
   revision = "79e00513b1011888b1e675157ab89f527f901cae"
 
 [[projects]]
-  digest = "1:3e892a54552313db9f7eda71126179f4da5c9d15778681c662f0ef44471698ee"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -53,141 +48,111 @@
     "params",
     "rlp",
     "rpc",
-    "trie",
+    "trie"
   ]
-  pruneopts = "T"
   revision = "37685930d953bcbe023f9bc65b135a8d8b8f1488"
   version = "v1.8.12"
 
 [[projects]]
-  digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
   name = "github.com/go-stack/stack"
   packages = ["."]
-  pruneopts = "T"
   revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
   version = "v1.8.0"
 
 [[projects]]
-  digest = "1:a2ecb56e5053d942aafc86738915fb94c9131bac848c543b8b6764365fd69080"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "T"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:6027b20c168728321bd99ad01f35118eded457b01c03e647a84833ab331f2f5b"
   name = "github.com/golang/snappy"
   packages = ["."]
-  pruneopts = "T"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
-  digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
   name = "github.com/gorilla/context"
   packages = ["."]
-  pruneopts = "T"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:e73f5b0152105f18bc131fba127d9949305c8693f8a762588a82a48f61756f5f"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  pruneopts = "T"
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:6e7f344f0759e7bd98e5d373e3149b5fca4132261c241777a1c8e57176f1fe05"
   name = "github.com/gxed/hashland"
   packages = ["keccakpg"]
-  pruneopts = "T"
   revision = "d9f6b97f8db22dd1e090fd0bbbe98f09cc7dd0a8"
 
 [[projects]]
-  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = "T"
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:8f20c8dd713564fa97299fbcb77d729c6de9c33f3222812a76e6ecfaef80fd61"
   name = "github.com/hpcloud/tail"
   packages = [
     ".",
     "ratelimiter",
     "util",
     "watch",
-    "winfile",
+    "winfile"
   ]
-  pruneopts = "T"
   revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:fa3a7dc0a780fb19838fb96d4e18c0b9a019d9bb618798308d7b6ca48fcb9876"
   name = "github.com/jbenet/go-base58"
   packages = ["."]
-  pruneopts = "T"
   revision = "6237cf65f3a6f7111cd8a42be3590df99a66bc7d"
   version = "1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:130cefe87d7eeefc824978dcb78e35672d4c49a11f25c153fbf0cfd952756fa3"
   name = "github.com/minio/blake2b-simd"
   packages = ["."]
-  pruneopts = "T"
   revision = "3f5f724cb5b182a5c278d6d3d55b40e7f8c2efb4"
 
 [[projects]]
   branch = "master"
-  digest = "1:17e048d1af8833670439d1ad0c92305fc1ad503e5d03f37ee667c0074df0fd03"
   name = "github.com/minio/sha256-simd"
   packages = ["."]
-  pruneopts = "T"
   revision = "ad98a36ba0da87206e3378c556abbfeaeaa98668"
 
 [[projects]]
   branch = "master"
-  digest = "1:9209bb830bd368966f88ce5f6b56b555d7e1925b4474b273038bded54749360e"
   name = "github.com/mr-tron/base58"
   packages = ["base58"]
-  pruneopts = "T"
   revision = "f84df45a6b88974a98d1473e9f0de0eac859a3d9"
 
 [[projects]]
   branch = "master"
-  digest = "1:ec5c1918a5f897bd6f2196846cdfad01ccfb8625bea6f7ea7f686156f402c5ef"
   name = "github.com/multiformats/go-multiaddr"
   packages = ["."]
-  pruneopts = "T"
   revision = "d6ad8896def6b8571037683cffd995e3a87b14fa"
 
 [[projects]]
   branch = "master"
-  digest = "1:d07386c234cc562e20cff8970d0e327bb37ba2e168075e0045d0b0205a0e57be"
   name = "github.com/multiformats/go-multihash"
   packages = ["."]
-  pruneopts = "T"
   revision = "bffb9dfeaca3b66c0accb675d2910407f3615eec"
 
 [[projects]]
-  digest = "1:99ec7b4370b05816679fe9ae77f1f8af4eae3df0abaeef8c3d2d42d86f55f549"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -207,14 +172,12 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types",
+    "types"
   ]
-  pruneopts = "T"
   revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:7343b611a01c3276e8d1bb69b38f94014dbe6bf92df545b069808f7e7531b802"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -228,23 +191,19 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types",
+    "types"
   ]
-  pruneopts = "T"
   revision = "b6ea1ea48f981d0f615a154a45eabb9dd466556d"
   version = "v1.4.1"
 
 [[projects]]
-  digest = "1:361de06aa7ae272616cbe71c3994a654cc6316324e30998e650f7765b20c5b33"
   name = "github.com/pborman/uuid"
   packages = ["."]
-  pruneopts = "T"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
   branch = "contract-upgrades"
-  digest = "1:7c4c23be2b2da0568ab7513e2b41157dcccf1b0a286d94f39ded092dff192d84"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -264,38 +223,30 @@
     "smpc",
     "stackint",
     "stackint/asm",
-    "swarm",
+    "swarm"
   ]
-  pruneopts = "T"
   revision = "24e7e2dbf5f614e26f1b196deb269a177dfac885"
 
 [[projects]]
-  digest = "1:602081d2a289d1f76ea90b806b0c61c19038d76504e9005ccb969864dbaee339"
   name = "github.com/rjeczalik/notify"
   packages = ["."]
-  pruneopts = "T"
   revision = "0f065fa99b48b842c3fd3e2c8b194c6f2b69f6b8"
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:6cae6970d70fc5fe75bf83c48ee33e9c4c561a62d0b033254bee8dd5942b815a"
   name = "github.com/rs/cors"
   packages = ["."]
-  pruneopts = "T"
   revision = "3fb1b69b103a84de38a19c3c6ec073dd6caa4d3f"
   version = "v1.5.0"
 
 [[projects]]
-  digest = "1:919bb3aa6d9d0b67648c219fa4925312bc3c2872da19e818fa769e9c97a2b643"
   name = "github.com/spaolacci/murmur3"
   packages = ["."]
-  pruneopts = "T"
   revision = "9f5d223c60793748f04a9d5b4b4eacddfc1f755d"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:ee395d0d8c1719b5a1407f34af93953b4763bacb19a8961aba5b6d312824da41"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -309,28 +260,24 @@
     "leveldb/opt",
     "leveldb/storage",
     "leveldb/table",
-    "leveldb/util",
+    "leveldb/util"
   ]
-  pruneopts = "T"
   revision = "ae2bd5eed72d46b28834ec3f60db3a3ebedd8dbd"
 
 [[projects]]
   branch = "master"
-  digest = "1:da29cbeb9d244918393b37243c008ab7128688fb017c966aaf876587c010bcdd"
   name = "golang.org/x/crypto"
   packages = [
     "blake2s",
     "pbkdf2",
     "ripemd160",
     "scrypt",
-    "sha3",
+    "sha3"
   ]
-  pruneopts = "T"
   revision = "182538f80094b6a8efaade63a8fd8e0d9d5843dd"
 
 [[projects]]
   branch = "master"
-  digest = "1:c96475ce8a4befca406926432f1a9dea8d17c1573fe99c3086055d28e0910bec"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -343,24 +290,20 @@
     "idna",
     "internal/timeseries",
     "trace",
-    "websocket",
+    "websocket"
   ]
-  pruneopts = "T"
   revision = "8a410e7b638dca158bf9e766925842f6651ff828"
 
 [[projects]]
   branch = "master"
-  digest = "1:9a36b4bcab9e134eca532df4e80927e808f39346d641c686877d41fdbabdd5cf"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
-    "unix",
+    "unix"
   ]
-  pruneopts = "T"
   revision = "49385e6e15226593f68b26af201feec29d5bba22"
 
 [[projects]]
-  digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -388,42 +331,34 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = "T"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:59a73243379bd5412feb268ec3d9ec0c55acb596ce15fdf937ec29ea6dab441f"
   name = "golang.org/x/time"
   packages = ["rate"]
-  pruneopts = "T"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
-  digest = "1:5e9594b3370fef04a0a16cc65bf7a1bafa026b02bbf767e6e625eb0f075595a6"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk",
+    "internal/fastwalk"
   ]
-  pruneopts = "T"
   revision = "4bc20fc7916bc21abba37451a6923cffa9a2cd3f"
 
 [[projects]]
   branch = "master"
-  digest = "1:960f1fa3f12667fe595c15c12523718ed8b1b5428c83d70da54bb014da9a4c1a"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  pruneopts = "T"
   revision = "c66870c02cf823ceb633bcd05be3c7cda29976f4"
 
 [[projects]]
-  digest = "1:a985c4820889930a08c19181d2aeb1c57ab1929bce7a66b781109dd1db8fb433"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -451,89 +386,51 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap",
+    "tap"
   ]
-  pruneopts = "T"
   revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
   version = "v1.14.0"
 
 [[projects]]
-  digest = "1:3ccd10c863188cfe0d936fcfe6a055c95362e43af8e7039e33baade846928e74"
   name = "gopkg.in/fatih/set.v0"
   packages = ["."]
-  pruneopts = "T"
   revision = "57907de300222151a123d29255ed17f5ed43fad3"
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:7fc160b460a6fc506b37fcca68332464c3f2cd57b6e3f111f26c5bbfd2d5518e"
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
-  pruneopts = "T"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   source = "https://github.com/fsnotify/fsnotify.git"
   version = "v1.4.7"
 
 [[projects]]
   branch = "v2"
-  digest = "1:dae137be246befa42ce4b48c0feff2c5796b8a5027139a283f31a21173744410"
   name = "gopkg.in/karalabe/cookiejar.v2"
   packages = ["collections/prque"]
-  pruneopts = "T"
   revision = "8dcd6a7f4951f6ff3ee9cbb919a06d8925822e57"
 
 [[projects]]
   branch = "v2"
-  digest = "1:3d3f9391ab615be8655ae0d686a1564f3fec413979bb1aaf018bac1ec1bb1cc7"
   name = "gopkg.in/natefinch/npipe.v2"
   packages = ["."]
-  pruneopts = "T"
   revision = "c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6"
 
 [[projects]]
   branch = "v1"
-  digest = "1:0caa92e17bc0b65a98c63e5bc76a9e844cd5e56493f8fdbb28fad101a16254d9"
   name = "gopkg.in/tomb.v1"
   packages = ["."]
-  pruneopts = "T"
   revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
-  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "T"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/ethereum/go-ethereum",
-    "github.com/ethereum/go-ethereum/accounts/abi",
-    "github.com/ethereum/go-ethereum/accounts/abi/bind",
-    "github.com/ethereum/go-ethereum/common",
-    "github.com/ethereum/go-ethereum/core/types",
-    "github.com/ethereum/go-ethereum/ethclient",
-    "github.com/ethereum/go-ethereum/event",
-    "github.com/ethereum/go-ethereum/rpc",
-    "github.com/gorilla/mux",
-    "github.com/onsi/ginkgo",
-    "github.com/onsi/gomega",
-    "github.com/republicprotocol/republic-go/contract",
-    "github.com/republicprotocol/republic-go/crypto",
-    "github.com/republicprotocol/republic-go/dispatch",
-    "github.com/republicprotocol/republic-go/grpc",
-    "github.com/republicprotocol/republic-go/identity",
-    "github.com/republicprotocol/republic-go/leveldb",
-    "github.com/republicprotocol/republic-go/logger",
-    "github.com/republicprotocol/republic-go/order",
-    "github.com/republicprotocol/republic-go/orderbook",
-    "github.com/republicprotocol/republic-go/registry",
-    "github.com/republicprotocol/republic-go/swarm",
-    "github.com/rs/cors",
-    "golang.org/x/time/rate",
-  ]
+  inputs-digest = "036428cdeea4b2e33635c1c8ec734a165815fd62805d7109c5b42ff86576db72"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -225,7 +225,7 @@
     "stackint/asm",
     "swarm"
   ]
-  revision = "19407fe8c7a5f4bd6003d8453d2f2573566cd31f"
+  revision = "da6d5b27dd6ee8c16a4955cf581b25ecb6c71e46"
 
 [[projects]]
   name = "github.com/rjeczalik/notify"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -90,6 +90,14 @@
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
+  digest = "1:3a26588bc48b96825977c1b3df964f8fd842cd6860cc26370588d3563433cf11"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
   name = "github.com/gorilla/context"
   packages = ["."]
@@ -246,12 +254,12 @@
   version = "v1.4.1"
 
 [[projects]]
-  digest = "1:361de06aa7ae272616cbe71c3994a654cc6316324e30998e650f7765b20c5b33"
+  digest = "1:e5d0bd87abc2781d14e274807a470acd180f0499f8bf5bb18606e9ec22ad9de9"
   name = "github.com/pborman/uuid"
   packages = ["."]
   pruneopts = "T"
-  revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
-  version = "v1.1"
+  revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
+  version = "v1.2"
 
 [[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
@@ -263,7 +271,7 @@
 
 [[projects]]
   branch = "nightly"
-  digest = "1:128ef54fe8f6102a53e4e3590c5caee00beab1769de9866124b715c170d8d369"
+  digest = "1:30226079aa00e3bde6305a8beb0eeac4946575d5eba0bae7a7ef883a5347e786"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -286,7 +294,7 @@
     "swarm",
   ]
   pruneopts = "T"
-  revision = "3fb2a88f5aef50d120102490330f899ea5881144"
+  revision = "94ef5e7d86bf85d8b4c52843c30b61cd2af2fbad"
 
 [[projects]]
   digest = "1:602081d2a289d1f76ea90b806b0c61c19038d76504e9005ccb969864dbaee339"
@@ -349,7 +357,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c96475ce8a4befca406926432f1a9dea8d17c1573fe99c3086055d28e0910bec"
+  digest = "1:2584347a8e1438435975f69490a9aff755899d57f9afc67798cd2ae49ac16aaf"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -365,18 +373,18 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "8a410e7b638dca158bf9e766925842f6651ff828"
+  revision = "161cd47e91fd58ac17490ef4d742dc98bb4cf60e"
 
 [[projects]]
   branch = "master"
-  digest = "1:bfa444982d49ce4ca1360599270a94de12a573ccd3bf04493c79bee09da3170b"
+  digest = "1:0a95be0d89180d56ab8682fdced38485dd04a0977b2e8300b7f2af35ca16714f"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "T"
-  revision = "2b024373dcd9800f0cae693839fac6ede8d64a8c"
+  revision = "8cf3aee429924738c56c34bb819c4ea8273fc434"
 
 [[projects]]
   digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,22 +3,17 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:79b02529d2120af44eaad5f7fee9ff7e003739d469e2c2767008b797d290e9fd"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
-  pruneopts = "T"
   revision = "18b896026201d8e1758468d9c5d5a558c69c5e9b"
 
 [[projects]]
   branch = "master"
-  digest = "1:b9f5e0f033febe59a62d01e78486c0dd9e4afc9ac5d240aee6ce78a927142e8b"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
-  pruneopts = "T"
   revision = "79e00513b1011888b1e675157ab89f527f901cae"
 
 [[projects]]
-  digest = "1:3e892a54552313db9f7eda71126179f4da5c9d15778681c662f0ef44471698ee"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -53,141 +48,111 @@
     "params",
     "rlp",
     "rpc",
-    "trie",
+    "trie"
   ]
-  pruneopts = "T"
   revision = "37685930d953bcbe023f9bc65b135a8d8b8f1488"
   version = "v1.8.12"
 
 [[projects]]
-  digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
   name = "github.com/go-stack/stack"
   packages = ["."]
-  pruneopts = "T"
   revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
   version = "v1.8.0"
 
 [[projects]]
-  digest = "1:a2ecb56e5053d942aafc86738915fb94c9131bac848c543b8b6764365fd69080"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "T"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:6027b20c168728321bd99ad01f35118eded457b01c03e647a84833ab331f2f5b"
   name = "github.com/golang/snappy"
   packages = ["."]
-  pruneopts = "T"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
-  digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
   name = "github.com/gorilla/context"
   packages = ["."]
-  pruneopts = "T"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:e73f5b0152105f18bc131fba127d9949305c8693f8a762588a82a48f61756f5f"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  pruneopts = "T"
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:6e7f344f0759e7bd98e5d373e3149b5fca4132261c241777a1c8e57176f1fe05"
   name = "github.com/gxed/hashland"
   packages = ["keccakpg"]
-  pruneopts = "T"
   revision = "d9f6b97f8db22dd1e090fd0bbbe98f09cc7dd0a8"
 
 [[projects]]
   branch = "master"
-  digest = "1:cf296baa185baae04a9a7004efee8511d08e2f5f51d4cbe5375da89722d681db"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
-  pruneopts = "T"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
-  digest = "1:8f20c8dd713564fa97299fbcb77d729c6de9c33f3222812a76e6ecfaef80fd61"
   name = "github.com/hpcloud/tail"
   packages = [
     ".",
     "ratelimiter",
     "util",
     "watch",
-    "winfile",
+    "winfile"
   ]
-  pruneopts = "T"
   revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:fa3a7dc0a780fb19838fb96d4e18c0b9a019d9bb618798308d7b6ca48fcb9876"
   name = "github.com/jbenet/go-base58"
   packages = ["."]
-  pruneopts = "T"
   revision = "6237cf65f3a6f7111cd8a42be3590df99a66bc7d"
   version = "1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:130cefe87d7eeefc824978dcb78e35672d4c49a11f25c153fbf0cfd952756fa3"
   name = "github.com/minio/blake2b-simd"
   packages = ["."]
-  pruneopts = "T"
   revision = "3f5f724cb5b182a5c278d6d3d55b40e7f8c2efb4"
 
 [[projects]]
   branch = "master"
-  digest = "1:17e048d1af8833670439d1ad0c92305fc1ad503e5d03f37ee667c0074df0fd03"
   name = "github.com/minio/sha256-simd"
   packages = ["."]
-  pruneopts = "T"
   revision = "ad98a36ba0da87206e3378c556abbfeaeaa98668"
 
 [[projects]]
   branch = "master"
-  digest = "1:9209bb830bd368966f88ce5f6b56b555d7e1925b4474b273038bded54749360e"
   name = "github.com/mr-tron/base58"
   packages = ["base58"]
-  pruneopts = "T"
   revision = "f84df45a6b88974a98d1473e9f0de0eac859a3d9"
 
 [[projects]]
   branch = "master"
-  digest = "1:ec5c1918a5f897bd6f2196846cdfad01ccfb8625bea6f7ea7f686156f402c5ef"
   name = "github.com/multiformats/go-multiaddr"
   packages = ["."]
-  pruneopts = "T"
   revision = "d6ad8896def6b8571037683cffd995e3a87b14fa"
 
 [[projects]]
   branch = "master"
-  digest = "1:d07386c234cc562e20cff8970d0e327bb37ba2e168075e0045d0b0205a0e57be"
   name = "github.com/multiformats/go-multihash"
   packages = ["."]
-  pruneopts = "T"
   revision = "bffb9dfeaca3b66c0accb675d2910407f3615eec"
 
 [[projects]]
-  digest = "1:99ec7b4370b05816679fe9ae77f1f8af4eae3df0abaeef8c3d2d42d86f55f549"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -207,14 +172,12 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types",
+    "types"
   ]
-  pruneopts = "T"
   revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:7343b611a01c3276e8d1bb69b38f94014dbe6bf92df545b069808f7e7531b802"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -228,23 +191,19 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types",
+    "types"
   ]
-  pruneopts = "T"
   revision = "b6ea1ea48f981d0f615a154a45eabb9dd466556d"
   version = "v1.4.1"
 
 [[projects]]
-  digest = "1:361de06aa7ae272616cbe71c3994a654cc6316324e30998e650f7765b20c5b33"
   name = "github.com/pborman/uuid"
   packages = ["."]
-  pruneopts = "T"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
   branch = "contract-upgrades"
-  digest = "1:f491b501565f5e776fcc5ff752fa6a20881fcb0a5bb9aa00fffee6e73f51cdf0"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -264,38 +223,30 @@
     "smpc",
     "stackint",
     "stackint/asm",
-    "swarm",
+    "swarm"
   ]
-  pruneopts = "T"
-  revision = "d70f8b788f8dfb58b2a0cd96413154df3d9393aa"
+  revision = "19407fe8c7a5f4bd6003d8453d2f2573566cd31f"
 
 [[projects]]
-  digest = "1:6afc433cbb471b1d32de92131245fb1f76000c9d88940265df4a512572a51b51"
   name = "github.com/rjeczalik/notify"
   packages = ["."]
-  pruneopts = "T"
   revision = "52ae50d8490436622a8941bd70c3dbe0acdd4bbf"
   version = "v0.9.0"
 
 [[projects]]
-  digest = "1:6cae6970d70fc5fe75bf83c48ee33e9c4c561a62d0b033254bee8dd5942b815a"
   name = "github.com/rs/cors"
   packages = ["."]
-  pruneopts = "T"
   revision = "3fb1b69b103a84de38a19c3c6ec073dd6caa4d3f"
   version = "v1.5.0"
 
 [[projects]]
-  digest = "1:919bb3aa6d9d0b67648c219fa4925312bc3c2872da19e818fa769e9c97a2b643"
   name = "github.com/spaolacci/murmur3"
   packages = ["."]
-  pruneopts = "T"
   revision = "9f5d223c60793748f04a9d5b4b4eacddfc1f755d"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:ee395d0d8c1719b5a1407f34af93953b4763bacb19a8961aba5b6d312824da41"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -309,28 +260,24 @@
     "leveldb/opt",
     "leveldb/storage",
     "leveldb/table",
-    "leveldb/util",
+    "leveldb/util"
   ]
-  pruneopts = "T"
   revision = "ae2bd5eed72d46b28834ec3f60db3a3ebedd8dbd"
 
 [[projects]]
   branch = "master"
-  digest = "1:da29cbeb9d244918393b37243c008ab7128688fb017c966aaf876587c010bcdd"
   name = "golang.org/x/crypto"
   packages = [
     "blake2s",
     "pbkdf2",
     "ripemd160",
     "scrypt",
-    "sha3",
+    "sha3"
   ]
-  pruneopts = "T"
   revision = "614d502a4dac94afa3a6ce146bd1736da82514c6"
 
 [[projects]]
   branch = "master"
-  digest = "1:c96475ce8a4befca406926432f1a9dea8d17c1573fe99c3086055d28e0910bec"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -343,24 +290,20 @@
     "idna",
     "internal/timeseries",
     "trace",
-    "websocket",
+    "websocket"
   ]
-  pruneopts = "T"
   revision = "8a410e7b638dca158bf9e766925842f6651ff828"
 
 [[projects]]
   branch = "master"
-  digest = "1:d031229a87f35e24ec61e28a3e110b32f0bfca3dce8c0c817001a29f4df6e173"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
-    "unix",
+    "unix"
   ]
-  pruneopts = "T"
   revision = "4910a1d54f876d7b22162a85f4d066d3ee649450"
 
 [[projects]]
-  digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -388,34 +331,28 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = "T"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:854d075b41117dab6ff576f4308da39f8a187de8ccb97debeaf652f99f60dbc3"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk",
+    "internal/fastwalk"
   ]
-  pruneopts = "T"
   revision = "6cd1fcedba52a3e8045a1c96970cec308e4a632c"
 
 [[projects]]
   branch = "master"
-  digest = "1:960f1fa3f12667fe595c15c12523718ed8b1b5428c83d70da54bb014da9a4c1a"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  pruneopts = "T"
   revision = "c66870c02cf823ceb633bcd05be3c7cda29976f4"
 
 [[projects]]
-  digest = "1:a985c4820889930a08c19181d2aeb1c57ab1929bce7a66b781109dd1db8fb433"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -443,81 +380,51 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap",
+    "tap"
   ]
-  pruneopts = "T"
   revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
   version = "v1.14.0"
 
 [[projects]]
-  digest = "1:3ccd10c863188cfe0d936fcfe6a055c95362e43af8e7039e33baade846928e74"
   name = "gopkg.in/fatih/set.v0"
   packages = ["."]
-  pruneopts = "T"
   revision = "57907de300222151a123d29255ed17f5ed43fad3"
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:7fc160b460a6fc506b37fcca68332464c3f2cd57b6e3f111f26c5bbfd2d5518e"
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
-  pruneopts = "T"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   source = "https://github.com/fsnotify/fsnotify.git"
   version = "v1.4.7"
 
 [[projects]]
   branch = "v2"
-  digest = "1:dae137be246befa42ce4b48c0feff2c5796b8a5027139a283f31a21173744410"
   name = "gopkg.in/karalabe/cookiejar.v2"
   packages = ["collections/prque"]
-  pruneopts = "T"
   revision = "8dcd6a7f4951f6ff3ee9cbb919a06d8925822e57"
 
 [[projects]]
   branch = "v2"
-  digest = "1:3d3f9391ab615be8655ae0d686a1564f3fec413979bb1aaf018bac1ec1bb1cc7"
   name = "gopkg.in/natefinch/npipe.v2"
   packages = ["."]
-  pruneopts = "T"
   revision = "c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6"
 
 [[projects]]
   branch = "v1"
-  digest = "1:0caa92e17bc0b65a98c63e5bc76a9e844cd5e56493f8fdbb28fad101a16254d9"
   name = "gopkg.in/tomb.v1"
   packages = ["."]
-  pruneopts = "T"
   revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
-  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "T"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/ethereum/go-ethereum/accounts/abi/bind",
-    "github.com/gorilla/mux",
-    "github.com/onsi/ginkgo",
-    "github.com/onsi/gomega",
-    "github.com/republicprotocol/republic-go/contract",
-    "github.com/republicprotocol/republic-go/crypto",
-    "github.com/republicprotocol/republic-go/dispatch",
-    "github.com/republicprotocol/republic-go/grpc",
-    "github.com/republicprotocol/republic-go/identity",
-    "github.com/republicprotocol/republic-go/leveldb",
-    "github.com/republicprotocol/republic-go/logger",
-    "github.com/republicprotocol/republic-go/order",
-    "github.com/republicprotocol/republic-go/orderbook",
-    "github.com/republicprotocol/republic-go/registry",
-    "github.com/republicprotocol/republic-go/swarm",
-    "github.com/rs/cors",
-  ]
+  inputs-digest = "518dcc6836ae8df784dc848b334bc75a5ae8ea1285c23bc50d6390345fbd4e23"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -244,7 +244,7 @@
 
 [[projects]]
   branch = "contract-upgrades"
-  digest = "1:6fd9291e7b2049f22d45b1b594c385d7babba2d79ab6be817d10aa07bdaac696"
+  digest = "1:e2dd36d1d271e481d61fe042aeb0c507947af0b0f287b439ff8c1dd37e57cd49"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -267,7 +267,7 @@
     "swarm",
   ]
   pruneopts = "T"
-  revision = "b1bb4a6612d1dcc6911f70e5fd60cb89a984c519"
+  revision = "2dbe5f1d654d587810e975d12505400c4805d6a6"
 
 [[projects]]
   digest = "1:602081d2a289d1f76ea90b806b0c61c19038d76504e9005ccb969864dbaee339"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,17 +3,22 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:fcee9109b202ec83e394090947c53d9a345c7843a8dd33dde5189ad0e75cbf63"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
+  pruneopts = "T"
   revision = "c2e37c381520048ad67de8a2ef5c471603282ab7"
 
 [[projects]]
   branch = "master"
+  digest = "1:f2d4beb3a1f1d5c59ed38864724bb098952c6230a22a226b30b8cb1dcb8daf79"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
+  pruneopts = "T"
   revision = "cff30e1d23fc9e800b2b5b4b41ef1817dda07e9f"
 
 [[projects]]
+  digest = "1:3e892a54552313db9f7eda71126179f4da5c9d15778681c662f0ef44471698ee"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -48,120 +53,152 @@
     "params",
     "rlp",
     "rpc",
-    "trie"
+    "trie",
   ]
+  pruneopts = "T"
   revision = "37685930d953bcbe023f9bc65b135a8d8b8f1488"
   version = "v1.8.12"
 
 [[projects]]
+  digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
   name = "github.com/go-stack/stack"
   packages = ["."]
+  pruneopts = "T"
   revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
   version = "v1.8.0"
 
 [[projects]]
+  digest = "1:a2ecb56e5053d942aafc86738915fb94c9131bac848c543b8b6764365fd69080"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "T"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:6027b20c168728321bd99ad01f35118eded457b01c03e647a84833ab331f2f5b"
   name = "github.com/golang/snappy"
   packages = ["."]
+  pruneopts = "T"
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
+  digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "T"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:e73f5b0152105f18bc131fba127d9949305c8693f8a762588a82a48f61756f5f"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "T"
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:6e7f344f0759e7bd98e5d373e3149b5fca4132261c241777a1c8e57176f1fe05"
   name = "github.com/gxed/hashland"
   packages = ["keccakpg"]
+  pruneopts = "T"
   revision = "d9f6b97f8db22dd1e090fd0bbbe98f09cc7dd0a8"
 
 [[projects]]
+  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "T"
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:8f20c8dd713564fa97299fbcb77d729c6de9c33f3222812a76e6ecfaef80fd61"
   name = "github.com/hpcloud/tail"
   packages = [
     ".",
     "ratelimiter",
     "util",
     "watch",
-    "winfile"
+    "winfile",
   ]
+  pruneopts = "T"
   revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:fa3a7dc0a780fb19838fb96d4e18c0b9a019d9bb618798308d7b6ca48fcb9876"
   name = "github.com/jbenet/go-base58"
   packages = ["."]
+  pruneopts = "T"
   revision = "6237cf65f3a6f7111cd8a42be3590df99a66bc7d"
   version = "1.0.0"
 
 [[projects]]
+  digest = "1:2106821001befed6a5783b54950030dd0614257d18bef539e46cae9afd02b89b"
   name = "github.com/lib/pq"
   packages = [
     ".",
-    "oid"
+    "oid",
   ]
+  pruneopts = "T"
   revision = "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:130cefe87d7eeefc824978dcb78e35672d4c49a11f25c153fbf0cfd952756fa3"
   name = "github.com/minio/blake2b-simd"
   packages = ["."]
+  pruneopts = "T"
   revision = "3f5f724cb5b182a5c278d6d3d55b40e7f8c2efb4"
 
 [[projects]]
   branch = "master"
+  digest = "1:17e048d1af8833670439d1ad0c92305fc1ad503e5d03f37ee667c0074df0fd03"
   name = "github.com/minio/sha256-simd"
   packages = ["."]
+  pruneopts = "T"
   revision = "ad98a36ba0da87206e3378c556abbfeaeaa98668"
 
 [[projects]]
   branch = "master"
+  digest = "1:9209bb830bd368966f88ce5f6b56b555d7e1925b4474b273038bded54749360e"
   name = "github.com/mr-tron/base58"
   packages = ["base58"]
+  pruneopts = "T"
   revision = "f84df45a6b88974a98d1473e9f0de0eac859a3d9"
 
 [[projects]]
   branch = "master"
+  digest = "1:ec5c1918a5f897bd6f2196846cdfad01ccfb8625bea6f7ea7f686156f402c5ef"
   name = "github.com/multiformats/go-multiaddr"
   packages = ["."]
+  pruneopts = "T"
   revision = "d6ad8896def6b8571037683cffd995e3a87b14fa"
 
 [[projects]]
   branch = "master"
+  digest = "1:d07386c234cc562e20cff8970d0e327bb37ba2e168075e0045d0b0205a0e57be"
   name = "github.com/multiformats/go-multihash"
   packages = ["."]
+  pruneopts = "T"
   revision = "bffb9dfeaca3b66c0accb675d2910407f3615eec"
 
 [[projects]]
+  digest = "1:99ec7b4370b05816679fe9ae77f1f8af4eae3df0abaeef8c3d2d42d86f55f549"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -181,12 +218,14 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types"
+    "types",
   ]
+  pruneopts = "T"
   revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
   version = "v1.6.0"
 
 [[projects]]
+  digest = "1:7343b611a01c3276e8d1bb69b38f94014dbe6bf92df545b069808f7e7531b802"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -200,25 +239,31 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types"
+    "types",
   ]
+  pruneopts = "T"
   revision = "b6ea1ea48f981d0f615a154a45eabb9dd466556d"
   version = "v1.4.1"
 
 [[projects]]
+  digest = "1:361de06aa7ae272616cbe71c3994a654cc6316324e30998e650f7765b20c5b33"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = "T"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "T"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "nightly"
+  digest = "1:128ef54fe8f6102a53e4e3590c5caee00beab1769de9866124b715c170d8d369"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -238,30 +283,38 @@
     "smpc",
     "stackint",
     "stackint/asm",
-    "swarm"
+    "swarm",
   ]
+  pruneopts = "T"
   revision = "3fb2a88f5aef50d120102490330f899ea5881144"
 
 [[projects]]
+  digest = "1:602081d2a289d1f76ea90b806b0c61c19038d76504e9005ccb969864dbaee339"
   name = "github.com/rjeczalik/notify"
   packages = ["."]
+  pruneopts = "T"
   revision = "0f065fa99b48b842c3fd3e2c8b194c6f2b69f6b8"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:6cae6970d70fc5fe75bf83c48ee33e9c4c561a62d0b033254bee8dd5942b815a"
   name = "github.com/rs/cors"
   packages = ["."]
+  pruneopts = "T"
   revision = "3fb1b69b103a84de38a19c3c6ec073dd6caa4d3f"
   version = "v1.5.0"
 
 [[projects]]
+  digest = "1:919bb3aa6d9d0b67648c219fa4925312bc3c2872da19e818fa769e9c97a2b643"
   name = "github.com/spaolacci/murmur3"
   packages = ["."]
+  pruneopts = "T"
   revision = "9f5d223c60793748f04a9d5b4b4eacddfc1f755d"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:ee395d0d8c1719b5a1407f34af93953b4763bacb19a8961aba5b6d312824da41"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -275,24 +328,28 @@
     "leveldb/opt",
     "leveldb/storage",
     "leveldb/table",
-    "leveldb/util"
+    "leveldb/util",
   ]
+  pruneopts = "T"
   revision = "ae2bd5eed72d46b28834ec3f60db3a3ebedd8dbd"
 
 [[projects]]
   branch = "master"
+  digest = "1:490cbeb7a0a743de4cc0058a6d13ef6772c4d1e3d4d36a8f0428d3c5114012ff"
   name = "golang.org/x/crypto"
   packages = [
     "blake2s",
     "pbkdf2",
     "ripemd160",
     "scrypt",
-    "sha3"
+    "sha3",
   ]
-  revision = "182538f80094b6a8efaade63a8fd8e0d9d5843dd"
+  pruneopts = "T"
+  revision = "0709b304e793a5edb4a2c0145f281ecdc20838a4"
 
 [[projects]]
   branch = "master"
+  digest = "1:c96475ce8a4befca406926432f1a9dea8d17c1573fe99c3086055d28e0910bec"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -305,20 +362,24 @@
     "idna",
     "internal/timeseries",
     "trace",
-    "websocket"
+    "websocket",
   ]
+  pruneopts = "T"
   revision = "8a410e7b638dca158bf9e766925842f6651ff828"
 
 [[projects]]
   branch = "master"
+  digest = "1:bfa444982d49ce4ca1360599270a94de12a573ccd3bf04493c79bee09da3170b"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
-    "unix"
+    "unix",
   ]
+  pruneopts = "T"
   revision = "2b024373dcd9800f0cae693839fac6ede8d64a8c"
 
 [[projects]]
+  digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -346,34 +407,42 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "T"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:59a73243379bd5412feb268ec3d9ec0c55acb596ce15fdf937ec29ea6dab441f"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "T"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
+  digest = "1:dbc233c3e91caaf82db96f3bc5fcd5aa783f7b645022fd4ffc471e36f06df946"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
     "imports",
-    "internal/fastwalk"
+    "internal/fastwalk",
   ]
-  revision = "7ca132754999accbaa5c1735eda29e7ce0f3bf03"
+  pruneopts = "T"
+  revision = "0aa4b8830f481fed77b73cf7cea2bc3129e05148"
 
 [[projects]]
   branch = "master"
+  digest = "1:e43f1cb3f488a0c2be85939c2a594636f60b442a12a196c778bd2d6c9aca3df7"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = "T"
   revision = "11092d34479b07829b72e10713b159248caf5dad"
 
 [[projects]]
+  digest = "1:a985c4820889930a08c19181d2aeb1c57ab1929bce7a66b781109dd1db8fb433"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -401,51 +470,90 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap"
+    "tap",
   ]
+  pruneopts = "T"
   revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
   version = "v1.14.0"
 
 [[projects]]
+  digest = "1:3ccd10c863188cfe0d936fcfe6a055c95362e43af8e7039e33baade846928e74"
   name = "gopkg.in/fatih/set.v0"
   packages = ["."]
+  pruneopts = "T"
   revision = "57907de300222151a123d29255ed17f5ed43fad3"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:7fc160b460a6fc506b37fcca68332464c3f2cd57b6e3f111f26c5bbfd2d5518e"
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
+  pruneopts = "T"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   source = "https://github.com/fsnotify/fsnotify.git"
   version = "v1.4.7"
 
 [[projects]]
   branch = "v2"
+  digest = "1:dae137be246befa42ce4b48c0feff2c5796b8a5027139a283f31a21173744410"
   name = "gopkg.in/karalabe/cookiejar.v2"
   packages = ["collections/prque"]
+  pruneopts = "T"
   revision = "8dcd6a7f4951f6ff3ee9cbb919a06d8925822e57"
 
 [[projects]]
   branch = "v2"
+  digest = "1:3d3f9391ab615be8655ae0d686a1564f3fec413979bb1aaf018bac1ec1bb1cc7"
   name = "gopkg.in/natefinch/npipe.v2"
   packages = ["."]
+  pruneopts = "T"
   revision = "c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6"
 
 [[projects]]
   branch = "v1"
+  digest = "1:0caa92e17bc0b65a98c63e5bc76a9e844cd5e56493f8fdbb28fad101a16254d9"
   name = "gopkg.in/tomb.v1"
   packages = ["."]
+  pruneopts = "T"
   revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "T"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b7798faf7840d77a922551b80b8655c03ae31103876341b1ac45b9f13a3f44fd"
+  input-imports = [
+    "github.com/ethereum/go-ethereum",
+    "github.com/ethereum/go-ethereum/accounts/abi",
+    "github.com/ethereum/go-ethereum/accounts/abi/bind",
+    "github.com/ethereum/go-ethereum/common",
+    "github.com/ethereum/go-ethereum/core/types",
+    "github.com/ethereum/go-ethereum/ethclient",
+    "github.com/ethereum/go-ethereum/event",
+    "github.com/ethereum/go-ethereum/rpc",
+    "github.com/gorilla/mux",
+    "github.com/lib/pq",
+    "github.com/onsi/ginkgo",
+    "github.com/onsi/gomega",
+    "github.com/republicprotocol/republic-go/contract",
+    "github.com/republicprotocol/republic-go/crypto",
+    "github.com/republicprotocol/republic-go/dispatch",
+    "github.com/republicprotocol/republic-go/grpc",
+    "github.com/republicprotocol/republic-go/identity",
+    "github.com/republicprotocol/republic-go/leveldb",
+    "github.com/republicprotocol/republic-go/logger",
+    "github.com/republicprotocol/republic-go/order",
+    "github.com/republicprotocol/republic-go/orderbook",
+    "github.com/republicprotocol/republic-go/registry",
+    "github.com/republicprotocol/republic-go/swarm",
+    "github.com/rs/cors",
+    "golang.org/x/time/rate",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,11 +11,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8ad24ea05e770b745b5c286b4f94cf73d5be87005680e36b2d0dd1de0a2f9fbf"
+  digest = "1:b9f5e0f033febe59a62d01e78486c0dd9e4afc9ac5d240aee6ce78a927142e8b"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
   pruneopts = "T"
-  revision = "d81d8877b8f327112e94e814937143a71d1692a7"
+  revision = "79e00513b1011888b1e675157ab89f527f901cae"
 
 [[projects]]
   digest = "1:3e892a54552313db9f7eda71126179f4da5c9d15778681c662f0ef44471698ee"
@@ -60,12 +60,12 @@
   version = "v1.8.12"
 
 [[projects]]
-  digest = "1:c4a2528ccbcabf90f9f3c464a5fc9e302d592861bbfd0b7135a7de8a943d0406"
+  digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
   name = "github.com/go-stack/stack"
   packages = ["."]
   pruneopts = "T"
-  revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
-  version = "v1.7.0"
+  revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
+  version = "v1.8.0"
 
 [[projects]]
   digest = "1:a2ecb56e5053d942aafc86738915fb94c9131bac848c543b8b6764365fd69080"
@@ -180,11 +180,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5267c0e75b319dc15937048139397e3f597be970891037bf5e1898910ff1f8d2"
+  digest = "1:d07386c234cc562e20cff8970d0e327bb37ba2e168075e0045d0b0205a0e57be"
   name = "github.com/multiformats/go-multihash"
   packages = ["."]
   pruneopts = "T"
-  revision = "8be2a682ab9f254311de1375145a2f78a809b07d"
+  revision = "bffb9dfeaca3b66c0accb675d2910407f3615eec"
 
 [[projects]]
   digest = "1:99ec7b4370b05816679fe9ae77f1f8af4eae3df0abaeef8c3d2d42d86f55f549"
@@ -243,8 +243,8 @@
   version = "v1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:476c8e9f0260e539164fef4728793b67cab3a6ca1857a00eb45d1b04c12a1aaa"
+  branch = "contract-upgrades"
+  digest = "1:f491b501565f5e776fcc5ff752fa6a20881fcb0a5bb9aa00fffee6e73f51cdf0"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -267,7 +267,7 @@
     "swarm",
   ]
   pruneopts = "T"
-  revision = "6398bb216ab60ee2a63b09a8a82c1baa59ae63cc"
+  revision = "d70f8b788f8dfb58b2a0cd96413154df3d9393aa"
 
 [[projects]]
   digest = "1:6afc433cbb471b1d32de92131245fb1f76000c9d88940265df4a512572a51b51"
@@ -330,7 +330,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b01dc6b0bd5be5f17e93883ce29c5daf1bbbae91dc48eb72277db52a5152207c"
+  digest = "1:c96475ce8a4befca406926432f1a9dea8d17c1573fe99c3086055d28e0910bec"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -346,18 +346,18 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "922f4815f713f213882e8ef45e0d315b164d705c"
+  revision = "8a410e7b638dca158bf9e766925842f6651ff828"
 
 [[projects]]
   branch = "master"
-  digest = "1:738098c9e3dfd4e8adde91f4769225ac5cdc216d8a6d0f1bf2a1ca90962d1207"
+  digest = "1:d031229a87f35e24ec61e28a3e110b32f0bfca3dce8c0c817001a29f4df6e173"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "T"
-  revision = "11551d06cbcc94edc80a0facaccbda56473c19c1"
+  revision = "4910a1d54f876d7b22162a85f4d066d3ee649450"
 
 [[projects]]
   digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
@@ -396,7 +396,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:911908ce1e3907298259031d972398db8c005272a7e2ded6785f665a218c7ebe"
+  digest = "1:854d075b41117dab6ff576f4308da39f8a187de8ccb97debeaf652f99f60dbc3"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -404,7 +404,7 @@
     "internal/fastwalk",
   ]
   pruneopts = "T"
-  revision = "ff6c8c104af2168da09d225428803f855a80b1ce"
+  revision = "6cd1fcedba52a3e8045a1c96970cec308e4a632c"
 
 [[projects]]
   branch = "master"
@@ -450,8 +450,10 @@
   version = "v1.14.0"
 
 [[projects]]
+  digest = "1:3ccd10c863188cfe0d936fcfe6a055c95362e43af8e7039e33baade846928e74"
   name = "gopkg.in/fatih/set.v0"
   packages = ["."]
+  pruneopts = "T"
   revision = "57907de300222151a123d29255ed17f5ed43fad3"
   version = "v0.1.0"
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,11 +3,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:79b02529d2120af44eaad5f7fee9ff7e003739d469e2c2767008b797d290e9fd"
+  digest = "1:6ef484844b7d71500256c410601ae369090c47fca5e49383c6a1932c0a8b4a82"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
   pruneopts = "T"
-  revision = "18b896026201d8e1758468d9c5d5a558c69c5e9b"
+  revision = "4dd728aa987e9168a1e609e4919921dbfac9bd7f"
 
 [[projects]]
   branch = "master"
@@ -114,15 +114,15 @@
   revision = "d9f6b97f8db22dd1e090fd0bbbe98f09cc7dd0a8"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cf296baa185baae04a9a7004efee8511d08e2f5f51d4cbe5375da89722d681db"
+  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = "T"
-  revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
 
 [[projects]]
   digest = "1:8f20c8dd713564fa97299fbcb77d729c6de9c33f3222812a76e6ecfaef80fd61"
@@ -244,7 +244,7 @@
 
 [[projects]]
   branch = "contract-upgrades"
-  digest = "1:953626a10c7062190627160f9dcc3106d86206327d4d1d88395d08134fe26c14"
+  digest = "1:dc463a39ea0802be5bbb3b05ccae389be005b12dc7cf46f238585e9e9f8c12e1"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -267,15 +267,15 @@
     "swarm",
   ]
   pruneopts = "T"
-  revision = "da6d5b27dd6ee8c16a4955cf581b25ecb6c71e46"
+  revision = "55a55682278c49feaec49f10678d5d5ecba983ca"
 
 [[projects]]
-  digest = "1:6afc433cbb471b1d32de92131245fb1f76000c9d88940265df4a512572a51b51"
+  digest = "1:602081d2a289d1f76ea90b806b0c61c19038d76504e9005ccb969864dbaee339"
   name = "github.com/rjeczalik/notify"
   packages = ["."]
   pruneopts = "T"
-  revision = "52ae50d8490436622a8941bd70c3dbe0acdd4bbf"
-  version = "v0.9.0"
+  revision = "0f065fa99b48b842c3fd3e2c8b194c6f2b69f6b8"
+  version = "v0.9.1"
 
 [[projects]]
   digest = "1:6cae6970d70fc5fe75bf83c48ee33e9c4c561a62d0b033254bee8dd5942b815a"
@@ -326,7 +326,7 @@
     "sha3",
   ]
   pruneopts = "T"
-  revision = "614d502a4dac94afa3a6ce146bd1736da82514c6"
+  revision = "182538f80094b6a8efaade63a8fd8e0d9d5843dd"
 
 [[projects]]
   branch = "master"
@@ -350,14 +350,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d031229a87f35e24ec61e28a3e110b32f0bfca3dce8c0c817001a29f4df6e173"
+  digest = "1:9a36b4bcab9e134eca532df4e80927e808f39346d641c686877d41fdbabdd5cf"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "T"
-  revision = "4910a1d54f876d7b22162a85f4d066d3ee649450"
+  revision = "49385e6e15226593f68b26af201feec29d5bba22"
 
 [[projects]]
   digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
@@ -404,7 +404,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:854d075b41117dab6ff576f4308da39f8a187de8ccb97debeaf652f99f60dbc3"
+  digest = "1:5e9594b3370fef04a0a16cc65bf7a1bafa026b02bbf767e6e625eb0f075595a6"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -412,7 +412,7 @@
     "internal/fastwalk",
   ]
   pruneopts = "T"
-  revision = "6cd1fcedba52a3e8045a1c96970cec308e4a632c"
+  revision = "4bc20fc7916bc21abba37451a6923cffa9a2cd3f"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@
 
 [[constraint]]
   name = "github.com/republicprotocol/republic-go"
-  branch = "null-pointer-protection"
+  branch = "contract-upgrades"
 
 # Temporary fix https://github.com/golang/dep/issues/1799
 [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@
 
 [[constraint]]
   name = "github.com/republicprotocol/republic-go"
-  branch = "contract-upgrades"
+  branch = "nightly"
 
 # Fix to resolve dependency issues within go-ethereum
 [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,5 +1,5 @@
 [metadata.heroku]
-  go-version = "1.10.3"
+  go-version = "1.10.4"
   root-package = "github.com/republicprotocol/renex-ingress-go"
   install = "./cmd/ingress"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,6 +11,11 @@
   name = "github.com/republicprotocol/republic-go"
   branch = "contract-upgrades"
 
+# Fix to resolve dependency issues within go-ethereum
+[[override]]
+  name = "gopkg.in/fatih/set.v0"
+  version = "v0.1.0"
+
 # Temporary fix https://github.com/golang/dep/issues/1799
 [[override]]
   name = "gopkg.in/fsnotify.v1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,7 +5,7 @@
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  version = "1.8.12"
+  version = "=1.8.12"
 
 [[constraint]]
   name = "github.com/republicprotocol/republic-go"
@@ -14,7 +14,7 @@
 # Fix to resolve dependency issues within go-ethereum
 [[override]]
   name = "gopkg.in/fatih/set.v0"
-  version = "v0.1.0"
+  version = "=0.1.0"
 
 # Temporary fix https://github.com/golang/dep/issues/1799
 [[override]]

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -95,7 +96,7 @@ func main() {
 	}
 
 	// New database for persistent storage
-	store, err := leveldb.NewStore("$HOME/data", 72*time.Hour, 24*time.Hour)
+	store, err := leveldb.NewStore(path.Join(os.Getenv("HOME"), "data"), 72*time.Hour, 24*time.Hour)
 	if err != nil {
 		log.Fatalf("cannot open leveldb: %v", err)
 	}

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -97,11 +97,11 @@ func main() {
 	swarmer := swarm.NewSwarmer(swarmClient, store.SwarmMultiAddressStore(), alphaNum, &crypter)
 
 	orderbookClient := grpc.NewOrderbookClient()
-	ingresser := ingress.NewIngress(&binder, swarmer, orderbookClient, 4*time.Second)
+	ingresser := ingress.NewIngress(crypter, &binder, swarmer, orderbookClient, 4*time.Second)
 	ingressAdapter := httpadapter.NewIngressAdapter(ingresser)
 
 	go func() {
-		// Add bootstrap nodes in the storer or load from the file .
+		// Add bootstrap nodes in the store or load from the file.
 		for _, multiAddr := range config.BootstrapMultiAddresses {
 			multi, err := store.SwarmMultiAddressStore().MultiAddress(multiAddr.Address())
 			if err != nil && err != swarm.ErrMultiAddressNotFound {

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -97,16 +97,12 @@ func main() {
 	swarmer := swarm.NewSwarmer(swarmClient, store.SwarmMultiAddressStore(), alphaNum, &crypter)
 
 	orderbookClient := grpc.NewOrderbookClient()
-	ingresser := ingress.NewIngress(crypter, &binder, swarmer, orderbookClient, 4*time.Second)
+	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, swarmer, orderbookClient, 4*time.Second)
 	ingressAdapter := httpadapter.NewIngressAdapter(ingresser)
 
 	go func() {
 		// Add bootstrap nodes in the store or load from the file.
 		for _, multiAddr := range config.BootstrapMultiAddresses {
-			if multiAddr.IsNil() {
-				logger.Network(logger.LevelError, "cannot store null bootstrap address from config file")
-				continue
-			}
 			_, err := store.SwarmMultiAddressStore().MultiAddress(multiAddr.Address())
 			if err == nil {
 				// Only add bootstrap multi-addresses that are not already in the store.

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -141,7 +141,7 @@ func main() {
 			}
 		}()
 
-		processErrs := ingresser.ProcessRequests(done)
+		processErrs := ingresser.[ProcessRequests(done)
 		go func() {
 			for err := range processErrs {
 				logger.Error(fmt.Sprintf("error processing: %v", err))

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	renExContract "github.com/republicprotocol/renex-ingress-go/contract"
 	"github.com/republicprotocol/renex-ingress-go/httpadapter"
 	"github.com/republicprotocol/renex-ingress-go/ingress"
 	"github.com/republicprotocol/republic-go/contract"
@@ -26,7 +27,8 @@ import (
 )
 
 type config struct {
-	Ethereum                contract.Config         `json:"ethereum"`
+	Ethereum                contract.Config         `json:"republic"`
+	RenExEthereum           renExContract.Config    `json:"renex"`
 	BootstrapMultiAddresses identity.MultiAddresses `json:"bootstrapMultiAddresses"`
 }
 
@@ -78,6 +80,15 @@ func main() {
 		log.Fatalf("cannot create contract binder: %v", err)
 	}
 
+	renExConn, err := renExContract.Connect(config.RenExEthereum)
+	if err != nil {
+		log.Fatalf("cannot connect to ethereum: %v", err)
+	}
+	renExBinder, err := renExContract.NewBinder(auth, renExConn)
+	if err != nil {
+		log.Fatalf("cannot create contract binder: %v", err)
+	}
+
 	// New database for persistent storage
 	store, err := leveldb.NewStore("$HOME/data", 72*time.Hour, 24*time.Hour)
 	if err != nil {
@@ -97,7 +108,7 @@ func main() {
 	swarmer := swarm.NewSwarmer(swarmClient, store.SwarmMultiAddressStore(), alphaNum, &crypter)
 
 	orderbookClient := grpc.NewOrderbookClient()
-	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, swarmer, orderbookClient, 4*time.Second)
+	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, &renExBinder, swarmer, orderbookClient, 4*time.Second)
 	ingressAdapter := httpadapter.NewIngressAdapter(ingresser)
 
 	go func() {

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -141,7 +141,7 @@ func main() {
 			}
 		}()
 
-		processErrs := ingresser.[ProcessRequests(done)
+		processErrs := ingresser.ProcessRequests(done)
 		go func() {
 			for err := range processErrs {
 				logger.Error(fmt.Sprintf("error processing: %v", err))

--- a/cmd/openOrder/openOrder.go
+++ b/cmd/openOrder/openOrder.go
@@ -61,19 +61,12 @@ func main() {
 	}
 	buy := order.NewOrder(order.TypeLimit, order.ParityBuy, order.SettlementRenEx, time.Now().Add(1*time.Hour), order.TokensDGXREN, onePrice, oneVol, oneVol, rand.Uint64())
 	sell := order.NewOrder(order.TypeLimit, order.ParitySell, order.SettlementRenEx, time.Now().Add(1*time.Hour), order.TokensDGXREN, onePrice, oneVol, oneVol, rand.Uint64())
-	ords := []order.Order{buy, sell}
+	orders := []order.Order{buy, sell}
 
-	for _, ord := range ords {
-		message := append([]byte("Republic Protocol: open: "), ord.ID[:]...)
-		signatureData := crypto.Keccak256([]byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(message))), message)
-		signature, err := keystore.Sign(signatureData)
-		if err != nil {
-			log.Fatalf("cannot sign order: %v", err)
-		}
-
+	for _, ord := range orders {
 		log.Printf("order = %v, from = %v", ord.ID, contractBinder.From().String())
 		request := httpadapter.OpenOrderRequest{
-			Signature:             base64.StdEncoding.EncodeToString(signature),
+			Address:               contractBinder.From().String(),
 			OrderFragmentMappings: httpadapter.OrderFragmentMappings{},
 		}
 

--- a/cmd/openOrder/openOrder.go
+++ b/cmd/openOrder/openOrder.go
@@ -51,16 +51,10 @@ func main() {
 		log.Fatalf("cannot load smart contract: %v", err)
 	}
 
-	onePrice := order.CoExp{
-		Co:  2,
-		Exp: 40,
-	}
-	oneVol := order.CoExp{
-		Co:  5,
-		Exp: 12,
-	}
-	buy := order.NewOrder(order.TypeLimit, order.ParityBuy, order.SettlementRenEx, time.Now().Add(1*time.Hour), order.TokensDGXREN, onePrice, oneVol, oneVol, rand.Uint64())
-	sell := order.NewOrder(order.TypeLimit, order.ParitySell, order.SettlementRenEx, time.Now().Add(1*time.Hour), order.TokensDGXREN, onePrice, oneVol, oneVol, rand.Uint64())
+	onePrice := uint64(1)
+	oneVol := uint64(1)
+	buy := order.NewOrder(order.ParityBuy, order.TypeLimit, time.Now().Add(1*time.Hour), order.SettlementRenEx, order.TokensDGXREN, onePrice, oneVol, oneVol, rand.Uint64())
+	sell := order.NewOrder( order.ParitySell, order.TypeLimit, time.Now().Add(1*time.Hour), order.SettlementRenEx,order.TokensDGXREN, onePrice, oneVol, oneVol, rand.Uint64())
 	orders := []order.Order{buy, sell}
 
 	for _, ord := range orders {

--- a/contract/binder.go
+++ b/contract/binder.go
@@ -1,0 +1,64 @@
+package contract
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/republicprotocol/renex-ingress-go/contract/bindings"
+)
+
+// Binder implements all methods that will communicate with the smart contracts
+type Binder struct {
+	mu           *sync.RWMutex
+	network      Network
+	conn         Conn
+	transactOpts *bind.TransactOpts
+	callOpts     *bind.CallOpts
+
+	renExBrokerVerifier *bindings.RenExBrokerVerifier
+}
+
+// NewBinder returns a Binder to communicate with contracts
+func NewBinder(auth *bind.TransactOpts, conn Conn) (Binder, error) {
+	transactOpts := *auth
+	transactOpts.GasPrice = big.NewInt(5000000000)
+
+	nonce, err := conn.Client.PendingNonceAt(context.Background(), transactOpts.From)
+	if err != nil {
+		return Binder{}, err
+	}
+	transactOpts.Nonce = big.NewInt(int64(nonce))
+
+	renExBrokerVerifier, err := bindings.NewRenExBrokerVerifier(common.HexToAddress(conn.Config.RenExBrokerVerifierAddress), bind.ContractBackend(conn.Client))
+	if err != nil {
+		fmt.Println(fmt.Errorf("cannot bind to RenExBrokerVerifier: %v", err))
+		return Binder{}, err
+	}
+
+	return Binder{
+		mu:           new(sync.RWMutex),
+		network:      conn.Config.Network,
+		conn:         conn,
+		transactOpts: &transactOpts,
+		callOpts:     &bind.CallOpts{},
+
+		renExBrokerVerifier: renExBrokerVerifier,
+	}, nil
+}
+
+// GetTraderWithdrawalNonce retrieves the withdrawal nonce for approving a
+// trader's withdrawal. A signature can only be used once.
+func (binder *Binder) GetTraderWithdrawalNonce(trader common.Address) (*big.Int, error) {
+	binder.mu.RLock()
+	defer binder.mu.RUnlock()
+
+	return binder.getTraderWithdrawalNonce(trader)
+}
+
+func (binder *Binder) getTraderWithdrawalNonce(trader common.Address) (*big.Int, error) {
+	return binder.renExBrokerVerifier.TraderNonces(binder.callOpts, trader)
+}

--- a/contract/bindings/brokerVerifier.go
+++ b/contract/bindings/brokerVerifier.go
@@ -1,0 +1,1923 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bindings
+
+import (
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// ECRecoveryABI is the input ABI used to generate the binding from.
+const ECRecoveryABI = "[]"
+
+// ECRecoveryBin is the compiled bytecode used for deploying new contracts.
+const ECRecoveryBin = `0x604c602c600b82828239805160001a60731460008114601c57601e565bfe5b5030600052607381538281f30073000000000000000000000000000000000000000030146080604052600080fd00a165627a7a7230582051ce5400e9db2ec99f60568a05f33dba86f40cf2f0c53aa9337bccedec093bd10029`
+
+// DeployECRecovery deploys a new Ethereum contract, binding an instance of ECRecovery to it.
+func DeployECRecovery(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *ECRecovery, error) {
+	parsed, err := abi.JSON(strings.NewReader(ECRecoveryABI))
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(ECRecoveryBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &ECRecovery{ECRecoveryCaller: ECRecoveryCaller{contract: contract}, ECRecoveryTransactor: ECRecoveryTransactor{contract: contract}, ECRecoveryFilterer: ECRecoveryFilterer{contract: contract}}, nil
+}
+
+// ECRecovery is an auto generated Go binding around an Ethereum contract.
+type ECRecovery struct {
+	ECRecoveryCaller     // Read-only binding to the contract
+	ECRecoveryTransactor // Write-only binding to the contract
+	ECRecoveryFilterer   // Log filterer for contract events
+}
+
+// ECRecoveryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ECRecoveryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ECRecoveryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ECRecoveryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ECRecoveryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ECRecoveryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ECRecoverySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ECRecoverySession struct {
+	Contract     *ECRecovery       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// ECRecoveryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ECRecoveryCallerSession struct {
+	Contract *ECRecoveryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// ECRecoveryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ECRecoveryTransactorSession struct {
+	Contract     *ECRecoveryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// ECRecoveryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ECRecoveryRaw struct {
+	Contract *ECRecovery // Generic contract binding to access the raw methods on
+}
+
+// ECRecoveryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ECRecoveryCallerRaw struct {
+	Contract *ECRecoveryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ECRecoveryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ECRecoveryTransactorRaw struct {
+	Contract *ECRecoveryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewECRecovery creates a new instance of ECRecovery, bound to a specific deployed contract.
+func NewECRecovery(address common.Address, backend bind.ContractBackend) (*ECRecovery, error) {
+	contract, err := bindECRecovery(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &ECRecovery{ECRecoveryCaller: ECRecoveryCaller{contract: contract}, ECRecoveryTransactor: ECRecoveryTransactor{contract: contract}, ECRecoveryFilterer: ECRecoveryFilterer{contract: contract}}, nil
+}
+
+// NewECRecoveryCaller creates a new read-only instance of ECRecovery, bound to a specific deployed contract.
+func NewECRecoveryCaller(address common.Address, caller bind.ContractCaller) (*ECRecoveryCaller, error) {
+	contract, err := bindECRecovery(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ECRecoveryCaller{contract: contract}, nil
+}
+
+// NewECRecoveryTransactor creates a new write-only instance of ECRecovery, bound to a specific deployed contract.
+func NewECRecoveryTransactor(address common.Address, transactor bind.ContractTransactor) (*ECRecoveryTransactor, error) {
+	contract, err := bindECRecovery(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ECRecoveryTransactor{contract: contract}, nil
+}
+
+// NewECRecoveryFilterer creates a new log filterer instance of ECRecovery, bound to a specific deployed contract.
+func NewECRecoveryFilterer(address common.Address, filterer bind.ContractFilterer) (*ECRecoveryFilterer, error) {
+	contract, err := bindECRecovery(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ECRecoveryFilterer{contract: contract}, nil
+}
+
+// bindECRecovery binds a generic wrapper to an already deployed contract.
+func bindECRecovery(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(ECRecoveryABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ECRecovery *ECRecoveryRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _ECRecovery.Contract.ECRecoveryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ECRecovery *ECRecoveryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ECRecovery.Contract.ECRecoveryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ECRecovery *ECRecoveryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ECRecovery.Contract.ECRecoveryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_ECRecovery *ECRecoveryCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _ECRecovery.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_ECRecovery *ECRecoveryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _ECRecovery.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_ECRecovery *ECRecoveryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _ECRecovery.Contract.contract.Transact(opts, method, params...)
+}
+
+// OwnableABI is the input ABI used to generate the binding from.
+const OwnableABI = "[{\"constant\":false,\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"previousOwner\",\"type\":\"address\"}],\"name\":\"OwnershipRenounced\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"}]"
+
+// OwnableBin is the compiled bytecode used for deploying new contracts.
+const OwnableBin = `0x608060405234801561001057600080fd5b5060008054600160a060020a0319163317905561020b806100326000396000f3006080604052600436106100565763ffffffff7c0100000000000000000000000000000000000000000000000000000000600035041663715018a6811461005b5780638da5cb5b14610072578063f2fde38b146100a3575b600080fd5b34801561006757600080fd5b506100706100c4565b005b34801561007e57600080fd5b50610087610130565b60408051600160a060020a039092168252519081900360200190f35b3480156100af57600080fd5b50610070600160a060020a036004351661013f565b600054600160a060020a031633146100db57600080fd5b60008054604051600160a060020a03909116917ff8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c6482091a26000805473ffffffffffffffffffffffffffffffffffffffff19169055565b600054600160a060020a031681565b600054600160a060020a0316331461015657600080fd5b61015f81610162565b50565b600160a060020a038116151561017757600080fd5b60008054604051600160a060020a03808516939216917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a36000805473ffffffffffffffffffffffffffffffffffffffff1916600160a060020a03929092169190911790555600a165627a7a72305820d07f4d5221378e0ccfc5230ace30fcd5568360922dc2baa242decb0ba9afd4100029`
+
+// DeployOwnable deploys a new Ethereum contract, binding an instance of Ownable to it.
+func DeployOwnable(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Ownable, error) {
+	parsed, err := abi.JSON(strings.NewReader(OwnableABI))
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(OwnableBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Ownable{OwnableCaller: OwnableCaller{contract: contract}, OwnableTransactor: OwnableTransactor{contract: contract}, OwnableFilterer: OwnableFilterer{contract: contract}}, nil
+}
+
+// Ownable is an auto generated Go binding around an Ethereum contract.
+type Ownable struct {
+	OwnableCaller     // Read-only binding to the contract
+	OwnableTransactor // Write-only binding to the contract
+	OwnableFilterer   // Log filterer for contract events
+}
+
+// OwnableCaller is an auto generated read-only Go binding around an Ethereum contract.
+type OwnableCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OwnableTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type OwnableTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OwnableFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type OwnableFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// OwnableSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type OwnableSession struct {
+	Contract     *Ownable          // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// OwnableCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type OwnableCallerSession struct {
+	Contract *OwnableCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts  // Call options to use throughout this session
+}
+
+// OwnableTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type OwnableTransactorSession struct {
+	Contract     *OwnableTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// OwnableRaw is an auto generated low-level Go binding around an Ethereum contract.
+type OwnableRaw struct {
+	Contract *Ownable // Generic contract binding to access the raw methods on
+}
+
+// OwnableCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type OwnableCallerRaw struct {
+	Contract *OwnableCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// OwnableTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type OwnableTransactorRaw struct {
+	Contract *OwnableTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewOwnable creates a new instance of Ownable, bound to a specific deployed contract.
+func NewOwnable(address common.Address, backend bind.ContractBackend) (*Ownable, error) {
+	contract, err := bindOwnable(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Ownable{OwnableCaller: OwnableCaller{contract: contract}, OwnableTransactor: OwnableTransactor{contract: contract}, OwnableFilterer: OwnableFilterer{contract: contract}}, nil
+}
+
+// NewOwnableCaller creates a new read-only instance of Ownable, bound to a specific deployed contract.
+func NewOwnableCaller(address common.Address, caller bind.ContractCaller) (*OwnableCaller, error) {
+	contract, err := bindOwnable(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableCaller{contract: contract}, nil
+}
+
+// NewOwnableTransactor creates a new write-only instance of Ownable, bound to a specific deployed contract.
+func NewOwnableTransactor(address common.Address, transactor bind.ContractTransactor) (*OwnableTransactor, error) {
+	contract, err := bindOwnable(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableTransactor{contract: contract}, nil
+}
+
+// NewOwnableFilterer creates a new log filterer instance of Ownable, bound to a specific deployed contract.
+func NewOwnableFilterer(address common.Address, filterer bind.ContractFilterer) (*OwnableFilterer, error) {
+	contract, err := bindOwnable(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableFilterer{contract: contract}, nil
+}
+
+// bindOwnable binds a generic wrapper to an already deployed contract.
+func bindOwnable(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(OwnableABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Ownable *OwnableRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Ownable.Contract.OwnableCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Ownable *OwnableRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Ownable.Contract.OwnableTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Ownable *OwnableRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Ownable.Contract.OwnableTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Ownable *OwnableCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Ownable.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Ownable *OwnableTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Ownable.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Ownable *OwnableTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Ownable.Contract.contract.Transact(opts, method, params...)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_Ownable *OwnableCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _Ownable.contract.Call(opts, out, "owner")
+	return *ret0, err
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_Ownable *OwnableSession) Owner() (common.Address, error) {
+	return _Ownable.Contract.Owner(&_Ownable.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_Ownable *OwnableCallerSession) Owner() (common.Address, error) {
+	return _Ownable.Contract.Owner(&_Ownable.CallOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Ownable *OwnableTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Ownable.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Ownable *OwnableSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Ownable.Contract.RenounceOwnership(&_Ownable.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Ownable *OwnableTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Ownable.Contract.RenounceOwnership(&_Ownable.TransactOpts)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_Ownable *OwnableTransactor) TransferOwnership(opts *bind.TransactOpts, _newOwner common.Address) (*types.Transaction, error) {
+	return _Ownable.contract.Transact(opts, "transferOwnership", _newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_Ownable *OwnableSession) TransferOwnership(_newOwner common.Address) (*types.Transaction, error) {
+	return _Ownable.Contract.TransferOwnership(&_Ownable.TransactOpts, _newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_Ownable *OwnableTransactorSession) TransferOwnership(_newOwner common.Address) (*types.Transaction, error) {
+	return _Ownable.Contract.TransferOwnership(&_Ownable.TransactOpts, _newOwner)
+}
+
+// OwnableOwnershipRenouncedIterator is returned from FilterOwnershipRenounced and is used to iterate over the raw logs and unpacked data for OwnershipRenounced events raised by the Ownable contract.
+type OwnableOwnershipRenouncedIterator struct {
+	Event *OwnableOwnershipRenounced // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OwnableOwnershipRenouncedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OwnableOwnershipRenounced)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OwnableOwnershipRenounced)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OwnableOwnershipRenouncedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OwnableOwnershipRenouncedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OwnableOwnershipRenounced represents a OwnershipRenounced event raised by the Ownable contract.
+type OwnableOwnershipRenounced struct {
+	PreviousOwner common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipRenounced is a free log retrieval operation binding the contract event 0xf8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c64820.
+//
+// Solidity: e OwnershipRenounced(previousOwner indexed address)
+func (_Ownable *OwnableFilterer) FilterOwnershipRenounced(opts *bind.FilterOpts, previousOwner []common.Address) (*OwnableOwnershipRenouncedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+
+	logs, sub, err := _Ownable.contract.FilterLogs(opts, "OwnershipRenounced", previousOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableOwnershipRenouncedIterator{contract: _Ownable.contract, event: "OwnershipRenounced", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipRenounced is a free log subscription operation binding the contract event 0xf8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c64820.
+//
+// Solidity: e OwnershipRenounced(previousOwner indexed address)
+func (_Ownable *OwnableFilterer) WatchOwnershipRenounced(opts *bind.WatchOpts, sink chan<- *OwnableOwnershipRenounced, previousOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+
+	logs, sub, err := _Ownable.contract.WatchLogs(opts, "OwnershipRenounced", previousOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OwnableOwnershipRenounced)
+				if err := _Ownable.contract.UnpackLog(event, "OwnershipRenounced", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// OwnableOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Ownable contract.
+type OwnableOwnershipTransferredIterator struct {
+	Event *OwnableOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *OwnableOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(OwnableOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(OwnableOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *OwnableOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *OwnableOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// OwnableOwnershipTransferred represents a OwnershipTransferred event raised by the Ownable contract.
+type OwnableOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: e OwnershipTransferred(previousOwner indexed address, newOwner indexed address)
+func (_Ownable *OwnableFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*OwnableOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Ownable.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnableOwnershipTransferredIterator{contract: _Ownable.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: e OwnershipTransferred(previousOwner indexed address, newOwner indexed address)
+func (_Ownable *OwnableFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *OwnableOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Ownable.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(OwnableOwnershipTransferred)
+				if err := _Ownable.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// RenExBrokerVerifierABI is the input ABI used to generate the binding from.
+const RenExBrokerVerifierABI = "[{\"constant\":true,\"inputs\":[{\"name\":\"_trader\",\"type\":\"address\"},{\"name\":\"_signature\",\"type\":\"bytes\"},{\"name\":\"_orderID\",\"type\":\"bytes32\"}],\"name\":\"verifyOpenSignature\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_broker\",\"type\":\"address\"}],\"name\":\"deregisterBroker\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"balancesContract\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"traderNonces\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"brokers\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_balancesContract\",\"type\":\"address\"}],\"name\":\"updateBalancesContract\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_trader\",\"type\":\"address\"},{\"name\":\"_signature\",\"type\":\"bytes\"}],\"name\":\"verifyWithdrawSignature\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_broker\",\"type\":\"address\"}],\"name\":\"registerBroker\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"VERSION\",\"outputs\":[{\"name\":\"\",\"type\":\"string\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_VERSION\",\"type\":\"string\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"previousBalancesContract\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"nextBalancesContract\",\"type\":\"address\"}],\"name\":\"LogBalancesContractUpdated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"broker\",\"type\":\"address\"}],\"name\":\"LogBrokerRegistered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"broker\",\"type\":\"address\"}],\"name\":\"LogBrokerDeregistered\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"previousOwner\",\"type\":\"address\"}],\"name\":\"OwnershipRenounced\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"}]"
+
+// RenExBrokerVerifierBin is the compiled bytecode used for deploying new contracts.
+const RenExBrokerVerifierBin = `0x608060405234801561001057600080fd5b50604051610e81380380610e8183398101604052805160008054600160a060020a0319163317905501805161004c906001906020840190610053565b50506100ee565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061009457805160ff19168380011785556100c1565b828001600101855582156100c1579182015b828111156100c15782518255916020019190600101906100a6565b506100cd9291506100d1565b5090565b6100eb91905b808211156100cd57600081556001016100d7565b90565b610d84806100fd6000396000f3006080604052600436106100b95763ffffffff7c0100000000000000000000000000000000000000000000000000000000600035041663472e191081146100be578063490618d1146101025780634a3d72a114610125578063506ee1ef1461015657806366874cc514610189578063715018a6146101aa5780638da5cb5b146101bf578063b8fd1e10146101d4578063c043df8c146101f5578063c684286814610222578063f2fde38b14610243578063ffa1ad7414610264575b600080fd5b3480156100ca57600080fd5b506100ee60048035600160a060020a031690602480359081019101356044356102ee565b604080519115158252519081900360200190f35b34801561010e57600080fd5b50610123600160a060020a03600435166103b8565b005b34801561013157600080fd5b5061013a6104b0565b60408051600160a060020a039092168252519081900360200190f35b34801561016257600080fd5b50610177600160a060020a03600435166104bf565b60408051918252519081900360200190f35b34801561019557600080fd5b506100ee600160a060020a03600435166104d1565b3480156101b657600080fd5b506101236104e6565b3480156101cb57600080fd5b5061013a610552565b3480156101e057600080fd5b50610123600160a060020a0360043516610561565b34801561020157600080fd5b506100ee60048035600160a060020a031690602480359081019101356105ef565b34801561022e57600080fd5b50610123600160a060020a0360043516610775565b34801561024f57600080fd5b50610123600160a060020a036004351661086f565b34801561027057600080fd5b50610279610892565b6040805160208082528351818301528351919283929083019185019080838360005b838110156102b357818101518382015260200161029b565b50505050905090810190601f1680156102e05780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b604080517f52657075626c69632050726f746f636f6c3a206f70656e3a20000000000000006020808301919091526c01000000000000000000000000600160a060020a038816026039830152604d80830185905283518084039091018152608d601f870183900490920283018201909352606d820185815260009392849261038d92859290918a918a918291018382808284375061091f945050505050565b600160a060020a031660009081526002602052604090205460ff161515600114979650505050505050565b600054600160a060020a031633146103cf57600080fd5b600160a060020a03811660009081526002602052604090205460ff16151561045857604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152600e60248201527f6e6f742072656769737465726564000000000000000000000000000000000000604482015290519081900360640190fd5b600160a060020a038116600081815260026020908152604091829020805460ff19169055815192835290517fe470a29f46ba9a09f7ec358ae2eb422a5a8f941f128ed7d8f5cf35278ab216409281900390910190a150565b600454600160a060020a031681565b60036020526000908152604090205481565b60026020526000908152604090205460ff1681565b600054600160a060020a031633146104fd57600080fd5b60008054604051600160a060020a03909116917ff8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c6482091a26000805473ffffffffffffffffffffffffffffffffffffffff19169055565b600054600160a060020a031681565b600054600160a060020a0316331461057857600080fd5b60045460408051600160a060020a039283168152918316602083015280517fa5d8d37e938531194e3b63a63c76ccbc603ebedcf3f3ebb9e02fc4ba843d34e29281900390910190a16004805473ffffffffffffffffffffffffffffffffffffffff1916600160a060020a0392909216919091179055565b6004546000906060908290600160a060020a0316331461067057604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152600e60248201527f6e6f7420617574686f72697a6564000000000000000000000000000000000000604482015290519081900360640190fd5b600160a060020a0386166000818152600360209081526040918290205482517f52657075626c69632050726f746f636f6c3a2077697468647261773a20000000818401526c01000000000000000000000000909402603d850152605180850191909152825180850390910181526091601f8901839004909202840182019092526071830187815291945061071a92859291899189918291018382808284375061091f945050505050565b600160a060020a03811660009081526002602052604090205490915060ff161561076757600160a060020a038616600090815260036020526040902080546001908101909155925061076c565b600092505b50509392505050565b600054600160a060020a0316331461078c57600080fd5b600160a060020a03811660009081526002602052604090205460ff161561081457604080517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601260248201527f616c726561647920726567697374657265640000000000000000000000000000604482015290519081900360640190fd5b600160a060020a038116600081815260026020908152604091829020805460ff19166001179055815192835290517fd4ba9549a2404d1e5bedd0a4ae90c79e2b41ce4dea6bef98dc999fec1f2784939281900390910190a150565b600054600160a060020a0316331461088657600080fd5b61088f81610ad9565b50565b60018054604080516020600284861615610100026000190190941693909304601f810184900484028201840190925281815292918301828280156109175780601f106108ec57610100808354040283529160200191610917565b820191906000526020600020905b8154815290600101906020018083116108fa57829003601f168201915b505050505081565b600060608060006040805190810160405280601a81526020017f19457468657265756d205369676e6564204d6573736167653a0a0000000000008152509250826109698751610b56565b876040516020018084805190602001908083835b6020831061099c5780518252601f19909201916020918201910161097d565b51815160209384036101000a600019018019909216911617905286519190930192860191508083835b602083106109e45780518252601f1990920191602091820191016109c5565b51815160209384036101000a600019018019909216911617905285519190930192850191508083835b60208310610a2c5780518252601f199092019160209182019101610a0d565b6001836020036101000a03801982511681845116808217855250505050505090500193505050506040516020818303038152906040529150816040518082805190602001908083835b60208310610a945780518252601f199092019160209182019101610a75565b6001836020036101000a03801982511681845116808217855250505050505090500191505060405180910390209050610acd8186610c88565b93505b50505092915050565b600160a060020a0381161515610aee57600080fd5b60008054604051600160a060020a03808516939216917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a36000805473ffffffffffffffffffffffffffffffffffffffff1916600160a060020a0392909216919091179055565b6060816000808381841515610ba05760408051808201909152600181527f300000000000000000000000000000000000000000000000000000000000000060208201529550610c7e565b600093508492505b6000831115610bc257600a83049250600184019350610ba8565b836040519080825280601f01601f191660200182016040528015610bf0578160200160208202803883390190505b509150600090505b83811015610c7a57600a85066030017f01000000000000000000000000000000000000000000000000000000000000000282600183870303815181101515610c3c57fe5b9060200101907effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1916908160001a905350600a85049450600101610bf8565b8195505b5050505050919050565b60008060008084516041141515610ca25760009350610ad0565b50505060208201516040830151606084015160001a601b60ff82161015610cc757601b015b8060ff16601b14158015610cdf57508060ff16601c14155b15610ced5760009350610ad0565b60408051600080825260208083018085528a905260ff8516838501526060830187905260808301869052925160019360a0808501949193601f19840193928390039091019190865af1158015610d47573d6000803e3d6000fd5b505050602060405103519350610ad05600a165627a7a723058201b38c93f1101294e29a8b939cfa8c370eef61283def8fb73eb027424927989d30029`
+
+// DeployRenExBrokerVerifier deploys a new Ethereum contract, binding an instance of RenExBrokerVerifier to it.
+func DeployRenExBrokerVerifier(auth *bind.TransactOpts, backend bind.ContractBackend, _VERSION string) (common.Address, *types.Transaction, *RenExBrokerVerifier, error) {
+	parsed, err := abi.JSON(strings.NewReader(RenExBrokerVerifierABI))
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(RenExBrokerVerifierBin), backend, _VERSION)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &RenExBrokerVerifier{RenExBrokerVerifierCaller: RenExBrokerVerifierCaller{contract: contract}, RenExBrokerVerifierTransactor: RenExBrokerVerifierTransactor{contract: contract}, RenExBrokerVerifierFilterer: RenExBrokerVerifierFilterer{contract: contract}}, nil
+}
+
+// RenExBrokerVerifier is an auto generated Go binding around an Ethereum contract.
+type RenExBrokerVerifier struct {
+	RenExBrokerVerifierCaller     // Read-only binding to the contract
+	RenExBrokerVerifierTransactor // Write-only binding to the contract
+	RenExBrokerVerifierFilterer   // Log filterer for contract events
+}
+
+// RenExBrokerVerifierCaller is an auto generated read-only Go binding around an Ethereum contract.
+type RenExBrokerVerifierCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RenExBrokerVerifierTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type RenExBrokerVerifierTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RenExBrokerVerifierFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type RenExBrokerVerifierFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// RenExBrokerVerifierSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type RenExBrokerVerifierSession struct {
+	Contract     *RenExBrokerVerifier // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts        // Call options to use throughout this session
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
+}
+
+// RenExBrokerVerifierCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type RenExBrokerVerifierCallerSession struct {
+	Contract *RenExBrokerVerifierCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts              // Call options to use throughout this session
+}
+
+// RenExBrokerVerifierTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type RenExBrokerVerifierTransactorSession struct {
+	Contract     *RenExBrokerVerifierTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts              // Transaction auth options to use throughout this session
+}
+
+// RenExBrokerVerifierRaw is an auto generated low-level Go binding around an Ethereum contract.
+type RenExBrokerVerifierRaw struct {
+	Contract *RenExBrokerVerifier // Generic contract binding to access the raw methods on
+}
+
+// RenExBrokerVerifierCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type RenExBrokerVerifierCallerRaw struct {
+	Contract *RenExBrokerVerifierCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// RenExBrokerVerifierTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type RenExBrokerVerifierTransactorRaw struct {
+	Contract *RenExBrokerVerifierTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewRenExBrokerVerifier creates a new instance of RenExBrokerVerifier, bound to a specific deployed contract.
+func NewRenExBrokerVerifier(address common.Address, backend bind.ContractBackend) (*RenExBrokerVerifier, error) {
+	contract, err := bindRenExBrokerVerifier(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &RenExBrokerVerifier{RenExBrokerVerifierCaller: RenExBrokerVerifierCaller{contract: contract}, RenExBrokerVerifierTransactor: RenExBrokerVerifierTransactor{contract: contract}, RenExBrokerVerifierFilterer: RenExBrokerVerifierFilterer{contract: contract}}, nil
+}
+
+// NewRenExBrokerVerifierCaller creates a new read-only instance of RenExBrokerVerifier, bound to a specific deployed contract.
+func NewRenExBrokerVerifierCaller(address common.Address, caller bind.ContractCaller) (*RenExBrokerVerifierCaller, error) {
+	contract, err := bindRenExBrokerVerifier(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RenExBrokerVerifierCaller{contract: contract}, nil
+}
+
+// NewRenExBrokerVerifierTransactor creates a new write-only instance of RenExBrokerVerifier, bound to a specific deployed contract.
+func NewRenExBrokerVerifierTransactor(address common.Address, transactor bind.ContractTransactor) (*RenExBrokerVerifierTransactor, error) {
+	contract, err := bindRenExBrokerVerifier(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &RenExBrokerVerifierTransactor{contract: contract}, nil
+}
+
+// NewRenExBrokerVerifierFilterer creates a new log filterer instance of RenExBrokerVerifier, bound to a specific deployed contract.
+func NewRenExBrokerVerifierFilterer(address common.Address, filterer bind.ContractFilterer) (*RenExBrokerVerifierFilterer, error) {
+	contract, err := bindRenExBrokerVerifier(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &RenExBrokerVerifierFilterer{contract: contract}, nil
+}
+
+// bindRenExBrokerVerifier binds a generic wrapper to an already deployed contract.
+func bindRenExBrokerVerifier(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(RenExBrokerVerifierABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_RenExBrokerVerifier *RenExBrokerVerifierRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _RenExBrokerVerifier.Contract.RenExBrokerVerifierCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_RenExBrokerVerifier *RenExBrokerVerifierRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.RenExBrokerVerifierTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_RenExBrokerVerifier *RenExBrokerVerifierRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.RenExBrokerVerifierTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_RenExBrokerVerifier *RenExBrokerVerifierCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _RenExBrokerVerifier.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.contract.Transact(opts, method, params...)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() constant returns(string)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCaller) VERSION(opts *bind.CallOpts) (string, error) {
+	var (
+		ret0 = new(string)
+	)
+	out := ret0
+	err := _RenExBrokerVerifier.contract.Call(opts, out, "VERSION")
+	return *ret0, err
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() constant returns(string)
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) VERSION() (string, error) {
+	return _RenExBrokerVerifier.Contract.VERSION(&_RenExBrokerVerifier.CallOpts)
+}
+
+// VERSION is a free data retrieval call binding the contract method 0xffa1ad74.
+//
+// Solidity: function VERSION() constant returns(string)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCallerSession) VERSION() (string, error) {
+	return _RenExBrokerVerifier.Contract.VERSION(&_RenExBrokerVerifier.CallOpts)
+}
+
+// BalancesContract is a free data retrieval call binding the contract method 0x4a3d72a1.
+//
+// Solidity: function balancesContract() constant returns(address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCaller) BalancesContract(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _RenExBrokerVerifier.contract.Call(opts, out, "balancesContract")
+	return *ret0, err
+}
+
+// BalancesContract is a free data retrieval call binding the contract method 0x4a3d72a1.
+//
+// Solidity: function balancesContract() constant returns(address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) BalancesContract() (common.Address, error) {
+	return _RenExBrokerVerifier.Contract.BalancesContract(&_RenExBrokerVerifier.CallOpts)
+}
+
+// BalancesContract is a free data retrieval call binding the contract method 0x4a3d72a1.
+//
+// Solidity: function balancesContract() constant returns(address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCallerSession) BalancesContract() (common.Address, error) {
+	return _RenExBrokerVerifier.Contract.BalancesContract(&_RenExBrokerVerifier.CallOpts)
+}
+
+// Brokers is a free data retrieval call binding the contract method 0x66874cc5.
+//
+// Solidity: function brokers( address) constant returns(bool)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCaller) Brokers(opts *bind.CallOpts, arg0 common.Address) (bool, error) {
+	var (
+		ret0 = new(bool)
+	)
+	out := ret0
+	err := _RenExBrokerVerifier.contract.Call(opts, out, "brokers", arg0)
+	return *ret0, err
+}
+
+// Brokers is a free data retrieval call binding the contract method 0x66874cc5.
+//
+// Solidity: function brokers( address) constant returns(bool)
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) Brokers(arg0 common.Address) (bool, error) {
+	return _RenExBrokerVerifier.Contract.Brokers(&_RenExBrokerVerifier.CallOpts, arg0)
+}
+
+// Brokers is a free data retrieval call binding the contract method 0x66874cc5.
+//
+// Solidity: function brokers( address) constant returns(bool)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCallerSession) Brokers(arg0 common.Address) (bool, error) {
+	return _RenExBrokerVerifier.Contract.Brokers(&_RenExBrokerVerifier.CallOpts, arg0)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _RenExBrokerVerifier.contract.Call(opts, out, "owner")
+	return *ret0, err
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) Owner() (common.Address, error) {
+	return _RenExBrokerVerifier.Contract.Owner(&_RenExBrokerVerifier.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCallerSession) Owner() (common.Address, error) {
+	return _RenExBrokerVerifier.Contract.Owner(&_RenExBrokerVerifier.CallOpts)
+}
+
+// TraderNonces is a free data retrieval call binding the contract method 0x506ee1ef.
+//
+// Solidity: function traderNonces( address) constant returns(uint256)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCaller) TraderNonces(opts *bind.CallOpts, arg0 common.Address) (*big.Int, error) {
+	var (
+		ret0 = new(*big.Int)
+	)
+	out := ret0
+	err := _RenExBrokerVerifier.contract.Call(opts, out, "traderNonces", arg0)
+	return *ret0, err
+}
+
+// TraderNonces is a free data retrieval call binding the contract method 0x506ee1ef.
+//
+// Solidity: function traderNonces( address) constant returns(uint256)
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) TraderNonces(arg0 common.Address) (*big.Int, error) {
+	return _RenExBrokerVerifier.Contract.TraderNonces(&_RenExBrokerVerifier.CallOpts, arg0)
+}
+
+// TraderNonces is a free data retrieval call binding the contract method 0x506ee1ef.
+//
+// Solidity: function traderNonces( address) constant returns(uint256)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCallerSession) TraderNonces(arg0 common.Address) (*big.Int, error) {
+	return _RenExBrokerVerifier.Contract.TraderNonces(&_RenExBrokerVerifier.CallOpts, arg0)
+}
+
+// VerifyOpenSignature is a free data retrieval call binding the contract method 0x472e1910.
+//
+// Solidity: function verifyOpenSignature(_trader address, _signature bytes, _orderID bytes32) constant returns(bool)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCaller) VerifyOpenSignature(opts *bind.CallOpts, _trader common.Address, _signature []byte, _orderID [32]byte) (bool, error) {
+	var (
+		ret0 = new(bool)
+	)
+	out := ret0
+	err := _RenExBrokerVerifier.contract.Call(opts, out, "verifyOpenSignature", _trader, _signature, _orderID)
+	return *ret0, err
+}
+
+// VerifyOpenSignature is a free data retrieval call binding the contract method 0x472e1910.
+//
+// Solidity: function verifyOpenSignature(_trader address, _signature bytes, _orderID bytes32) constant returns(bool)
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) VerifyOpenSignature(_trader common.Address, _signature []byte, _orderID [32]byte) (bool, error) {
+	return _RenExBrokerVerifier.Contract.VerifyOpenSignature(&_RenExBrokerVerifier.CallOpts, _trader, _signature, _orderID)
+}
+
+// VerifyOpenSignature is a free data retrieval call binding the contract method 0x472e1910.
+//
+// Solidity: function verifyOpenSignature(_trader address, _signature bytes, _orderID bytes32) constant returns(bool)
+func (_RenExBrokerVerifier *RenExBrokerVerifierCallerSession) VerifyOpenSignature(_trader common.Address, _signature []byte, _orderID [32]byte) (bool, error) {
+	return _RenExBrokerVerifier.Contract.VerifyOpenSignature(&_RenExBrokerVerifier.CallOpts, _trader, _signature, _orderID)
+}
+
+// DeregisterBroker is a paid mutator transaction binding the contract method 0x490618d1.
+//
+// Solidity: function deregisterBroker(_broker address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactor) DeregisterBroker(opts *bind.TransactOpts, _broker common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.contract.Transact(opts, "deregisterBroker", _broker)
+}
+
+// DeregisterBroker is a paid mutator transaction binding the contract method 0x490618d1.
+//
+// Solidity: function deregisterBroker(_broker address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) DeregisterBroker(_broker common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.DeregisterBroker(&_RenExBrokerVerifier.TransactOpts, _broker)
+}
+
+// DeregisterBroker is a paid mutator transaction binding the contract method 0x490618d1.
+//
+// Solidity: function deregisterBroker(_broker address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactorSession) DeregisterBroker(_broker common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.DeregisterBroker(&_RenExBrokerVerifier.TransactOpts, _broker)
+}
+
+// RegisterBroker is a paid mutator transaction binding the contract method 0xc6842868.
+//
+// Solidity: function registerBroker(_broker address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactor) RegisterBroker(opts *bind.TransactOpts, _broker common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.contract.Transact(opts, "registerBroker", _broker)
+}
+
+// RegisterBroker is a paid mutator transaction binding the contract method 0xc6842868.
+//
+// Solidity: function registerBroker(_broker address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) RegisterBroker(_broker common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.RegisterBroker(&_RenExBrokerVerifier.TransactOpts, _broker)
+}
+
+// RegisterBroker is a paid mutator transaction binding the contract method 0xc6842868.
+//
+// Solidity: function registerBroker(_broker address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactorSession) RegisterBroker(_broker common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.RegisterBroker(&_RenExBrokerVerifier.TransactOpts, _broker)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) RenounceOwnership() (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.RenounceOwnership(&_RenExBrokerVerifier.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.RenounceOwnership(&_RenExBrokerVerifier.TransactOpts)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactor) TransferOwnership(opts *bind.TransactOpts, _newOwner common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.contract.Transact(opts, "transferOwnership", _newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) TransferOwnership(_newOwner common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.TransferOwnership(&_RenExBrokerVerifier.TransactOpts, _newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactorSession) TransferOwnership(_newOwner common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.TransferOwnership(&_RenExBrokerVerifier.TransactOpts, _newOwner)
+}
+
+// UpdateBalancesContract is a paid mutator transaction binding the contract method 0xb8fd1e10.
+//
+// Solidity: function updateBalancesContract(_balancesContract address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactor) UpdateBalancesContract(opts *bind.TransactOpts, _balancesContract common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.contract.Transact(opts, "updateBalancesContract", _balancesContract)
+}
+
+// UpdateBalancesContract is a paid mutator transaction binding the contract method 0xb8fd1e10.
+//
+// Solidity: function updateBalancesContract(_balancesContract address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) UpdateBalancesContract(_balancesContract common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.UpdateBalancesContract(&_RenExBrokerVerifier.TransactOpts, _balancesContract)
+}
+
+// UpdateBalancesContract is a paid mutator transaction binding the contract method 0xb8fd1e10.
+//
+// Solidity: function updateBalancesContract(_balancesContract address) returns()
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactorSession) UpdateBalancesContract(_balancesContract common.Address) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.UpdateBalancesContract(&_RenExBrokerVerifier.TransactOpts, _balancesContract)
+}
+
+// VerifyWithdrawSignature is a paid mutator transaction binding the contract method 0xc043df8c.
+//
+// Solidity: function verifyWithdrawSignature(_trader address, _signature bytes) returns(bool)
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactor) VerifyWithdrawSignature(opts *bind.TransactOpts, _trader common.Address, _signature []byte) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.contract.Transact(opts, "verifyWithdrawSignature", _trader, _signature)
+}
+
+// VerifyWithdrawSignature is a paid mutator transaction binding the contract method 0xc043df8c.
+//
+// Solidity: function verifyWithdrawSignature(_trader address, _signature bytes) returns(bool)
+func (_RenExBrokerVerifier *RenExBrokerVerifierSession) VerifyWithdrawSignature(_trader common.Address, _signature []byte) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.VerifyWithdrawSignature(&_RenExBrokerVerifier.TransactOpts, _trader, _signature)
+}
+
+// VerifyWithdrawSignature is a paid mutator transaction binding the contract method 0xc043df8c.
+//
+// Solidity: function verifyWithdrawSignature(_trader address, _signature bytes) returns(bool)
+func (_RenExBrokerVerifier *RenExBrokerVerifierTransactorSession) VerifyWithdrawSignature(_trader common.Address, _signature []byte) (*types.Transaction, error) {
+	return _RenExBrokerVerifier.Contract.VerifyWithdrawSignature(&_RenExBrokerVerifier.TransactOpts, _trader, _signature)
+}
+
+// RenExBrokerVerifierLogBalancesContractUpdatedIterator is returned from FilterLogBalancesContractUpdated and is used to iterate over the raw logs and unpacked data for LogBalancesContractUpdated events raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierLogBalancesContractUpdatedIterator struct {
+	Event *RenExBrokerVerifierLogBalancesContractUpdated // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RenExBrokerVerifierLogBalancesContractUpdatedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RenExBrokerVerifierLogBalancesContractUpdated)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RenExBrokerVerifierLogBalancesContractUpdated)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RenExBrokerVerifierLogBalancesContractUpdatedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RenExBrokerVerifierLogBalancesContractUpdatedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RenExBrokerVerifierLogBalancesContractUpdated represents a LogBalancesContractUpdated event raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierLogBalancesContractUpdated struct {
+	PreviousBalancesContract common.Address
+	NextBalancesContract     common.Address
+	Raw                      types.Log // Blockchain specific contextual infos
+}
+
+// FilterLogBalancesContractUpdated is a free log retrieval operation binding the contract event 0xa5d8d37e938531194e3b63a63c76ccbc603ebedcf3f3ebb9e02fc4ba843d34e2.
+//
+// Solidity: e LogBalancesContractUpdated(previousBalancesContract address, nextBalancesContract address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) FilterLogBalancesContractUpdated(opts *bind.FilterOpts) (*RenExBrokerVerifierLogBalancesContractUpdatedIterator, error) {
+
+	logs, sub, err := _RenExBrokerVerifier.contract.FilterLogs(opts, "LogBalancesContractUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return &RenExBrokerVerifierLogBalancesContractUpdatedIterator{contract: _RenExBrokerVerifier.contract, event: "LogBalancesContractUpdated", logs: logs, sub: sub}, nil
+}
+
+// WatchLogBalancesContractUpdated is a free log subscription operation binding the contract event 0xa5d8d37e938531194e3b63a63c76ccbc603ebedcf3f3ebb9e02fc4ba843d34e2.
+//
+// Solidity: e LogBalancesContractUpdated(previousBalancesContract address, nextBalancesContract address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) WatchLogBalancesContractUpdated(opts *bind.WatchOpts, sink chan<- *RenExBrokerVerifierLogBalancesContractUpdated) (event.Subscription, error) {
+
+	logs, sub, err := _RenExBrokerVerifier.contract.WatchLogs(opts, "LogBalancesContractUpdated")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RenExBrokerVerifierLogBalancesContractUpdated)
+				if err := _RenExBrokerVerifier.contract.UnpackLog(event, "LogBalancesContractUpdated", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// RenExBrokerVerifierLogBrokerDeregisteredIterator is returned from FilterLogBrokerDeregistered and is used to iterate over the raw logs and unpacked data for LogBrokerDeregistered events raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierLogBrokerDeregisteredIterator struct {
+	Event *RenExBrokerVerifierLogBrokerDeregistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RenExBrokerVerifierLogBrokerDeregisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RenExBrokerVerifierLogBrokerDeregistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RenExBrokerVerifierLogBrokerDeregistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RenExBrokerVerifierLogBrokerDeregisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RenExBrokerVerifierLogBrokerDeregisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RenExBrokerVerifierLogBrokerDeregistered represents a LogBrokerDeregistered event raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierLogBrokerDeregistered struct {
+	Broker common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterLogBrokerDeregistered is a free log retrieval operation binding the contract event 0xe470a29f46ba9a09f7ec358ae2eb422a5a8f941f128ed7d8f5cf35278ab21640.
+//
+// Solidity: e LogBrokerDeregistered(broker address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) FilterLogBrokerDeregistered(opts *bind.FilterOpts) (*RenExBrokerVerifierLogBrokerDeregisteredIterator, error) {
+
+	logs, sub, err := _RenExBrokerVerifier.contract.FilterLogs(opts, "LogBrokerDeregistered")
+	if err != nil {
+		return nil, err
+	}
+	return &RenExBrokerVerifierLogBrokerDeregisteredIterator{contract: _RenExBrokerVerifier.contract, event: "LogBrokerDeregistered", logs: logs, sub: sub}, nil
+}
+
+// WatchLogBrokerDeregistered is a free log subscription operation binding the contract event 0xe470a29f46ba9a09f7ec358ae2eb422a5a8f941f128ed7d8f5cf35278ab21640.
+//
+// Solidity: e LogBrokerDeregistered(broker address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) WatchLogBrokerDeregistered(opts *bind.WatchOpts, sink chan<- *RenExBrokerVerifierLogBrokerDeregistered) (event.Subscription, error) {
+
+	logs, sub, err := _RenExBrokerVerifier.contract.WatchLogs(opts, "LogBrokerDeregistered")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RenExBrokerVerifierLogBrokerDeregistered)
+				if err := _RenExBrokerVerifier.contract.UnpackLog(event, "LogBrokerDeregistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// RenExBrokerVerifierLogBrokerRegisteredIterator is returned from FilterLogBrokerRegistered and is used to iterate over the raw logs and unpacked data for LogBrokerRegistered events raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierLogBrokerRegisteredIterator struct {
+	Event *RenExBrokerVerifierLogBrokerRegistered // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RenExBrokerVerifierLogBrokerRegisteredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RenExBrokerVerifierLogBrokerRegistered)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RenExBrokerVerifierLogBrokerRegistered)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RenExBrokerVerifierLogBrokerRegisteredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RenExBrokerVerifierLogBrokerRegisteredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RenExBrokerVerifierLogBrokerRegistered represents a LogBrokerRegistered event raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierLogBrokerRegistered struct {
+	Broker common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterLogBrokerRegistered is a free log retrieval operation binding the contract event 0xd4ba9549a2404d1e5bedd0a4ae90c79e2b41ce4dea6bef98dc999fec1f278493.
+//
+// Solidity: e LogBrokerRegistered(broker address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) FilterLogBrokerRegistered(opts *bind.FilterOpts) (*RenExBrokerVerifierLogBrokerRegisteredIterator, error) {
+
+	logs, sub, err := _RenExBrokerVerifier.contract.FilterLogs(opts, "LogBrokerRegistered")
+	if err != nil {
+		return nil, err
+	}
+	return &RenExBrokerVerifierLogBrokerRegisteredIterator{contract: _RenExBrokerVerifier.contract, event: "LogBrokerRegistered", logs: logs, sub: sub}, nil
+}
+
+// WatchLogBrokerRegistered is a free log subscription operation binding the contract event 0xd4ba9549a2404d1e5bedd0a4ae90c79e2b41ce4dea6bef98dc999fec1f278493.
+//
+// Solidity: e LogBrokerRegistered(broker address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) WatchLogBrokerRegistered(opts *bind.WatchOpts, sink chan<- *RenExBrokerVerifierLogBrokerRegistered) (event.Subscription, error) {
+
+	logs, sub, err := _RenExBrokerVerifier.contract.WatchLogs(opts, "LogBrokerRegistered")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RenExBrokerVerifierLogBrokerRegistered)
+				if err := _RenExBrokerVerifier.contract.UnpackLog(event, "LogBrokerRegistered", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// RenExBrokerVerifierOwnershipRenouncedIterator is returned from FilterOwnershipRenounced and is used to iterate over the raw logs and unpacked data for OwnershipRenounced events raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierOwnershipRenouncedIterator struct {
+	Event *RenExBrokerVerifierOwnershipRenounced // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RenExBrokerVerifierOwnershipRenouncedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RenExBrokerVerifierOwnershipRenounced)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RenExBrokerVerifierOwnershipRenounced)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RenExBrokerVerifierOwnershipRenouncedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RenExBrokerVerifierOwnershipRenouncedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RenExBrokerVerifierOwnershipRenounced represents a OwnershipRenounced event raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierOwnershipRenounced struct {
+	PreviousOwner common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipRenounced is a free log retrieval operation binding the contract event 0xf8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c64820.
+//
+// Solidity: e OwnershipRenounced(previousOwner indexed address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) FilterOwnershipRenounced(opts *bind.FilterOpts, previousOwner []common.Address) (*RenExBrokerVerifierOwnershipRenouncedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+
+	logs, sub, err := _RenExBrokerVerifier.contract.FilterLogs(opts, "OwnershipRenounced", previousOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RenExBrokerVerifierOwnershipRenouncedIterator{contract: _RenExBrokerVerifier.contract, event: "OwnershipRenounced", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipRenounced is a free log subscription operation binding the contract event 0xf8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c64820.
+//
+// Solidity: e OwnershipRenounced(previousOwner indexed address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) WatchOwnershipRenounced(opts *bind.WatchOpts, sink chan<- *RenExBrokerVerifierOwnershipRenounced, previousOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+
+	logs, sub, err := _RenExBrokerVerifier.contract.WatchLogs(opts, "OwnershipRenounced", previousOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RenExBrokerVerifierOwnershipRenounced)
+				if err := _RenExBrokerVerifier.contract.UnpackLog(event, "OwnershipRenounced", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// RenExBrokerVerifierOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierOwnershipTransferredIterator struct {
+	Event *RenExBrokerVerifierOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *RenExBrokerVerifierOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(RenExBrokerVerifierOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(RenExBrokerVerifierOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *RenExBrokerVerifierOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *RenExBrokerVerifierOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// RenExBrokerVerifierOwnershipTransferred represents a OwnershipTransferred event raised by the RenExBrokerVerifier contract.
+type RenExBrokerVerifierOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: e OwnershipTransferred(previousOwner indexed address, newOwner indexed address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*RenExBrokerVerifierOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _RenExBrokerVerifier.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &RenExBrokerVerifierOwnershipTransferredIterator{contract: _RenExBrokerVerifier.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: e OwnershipTransferred(previousOwner indexed address, newOwner indexed address)
+func (_RenExBrokerVerifier *RenExBrokerVerifierFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RenExBrokerVerifierOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _RenExBrokerVerifier.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(RenExBrokerVerifierOwnershipTransferred)
+				if err := _RenExBrokerVerifier.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// UtilsABI is the input ABI used to generate the binding from.
+const UtilsABI = "[]"
+
+// UtilsBin is the compiled bytecode used for deploying new contracts.
+const UtilsBin = `0x604c602c600b82828239805160001a60731460008114601c57601e565bfe5b5030600052607381538281f30073000000000000000000000000000000000000000030146080604052600080fd00a165627a7a7230582001a72e96e30964cc9ea0e910abb2eca43143887c0c9e7633f2a66ce369e3e03d0029`
+
+// DeployUtils deploys a new Ethereum contract, binding an instance of Utils to it.
+func DeployUtils(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *Utils, error) {
+	parsed, err := abi.JSON(strings.NewReader(UtilsABI))
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	address, tx, contract, err := bind.DeployContract(auth, parsed, common.FromHex(UtilsBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &Utils{UtilsCaller: UtilsCaller{contract: contract}, UtilsTransactor: UtilsTransactor{contract: contract}, UtilsFilterer: UtilsFilterer{contract: contract}}, nil
+}
+
+// Utils is an auto generated Go binding around an Ethereum contract.
+type Utils struct {
+	UtilsCaller     // Read-only binding to the contract
+	UtilsTransactor // Write-only binding to the contract
+	UtilsFilterer   // Log filterer for contract events
+}
+
+// UtilsCaller is an auto generated read-only Go binding around an Ethereum contract.
+type UtilsCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UtilsTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type UtilsTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UtilsFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type UtilsFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// UtilsSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type UtilsSession struct {
+	Contract     *Utils            // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// UtilsCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type UtilsCallerSession struct {
+	Contract *UtilsCaller  // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// UtilsTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type UtilsTransactorSession struct {
+	Contract     *UtilsTransactor  // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// UtilsRaw is an auto generated low-level Go binding around an Ethereum contract.
+type UtilsRaw struct {
+	Contract *Utils // Generic contract binding to access the raw methods on
+}
+
+// UtilsCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type UtilsCallerRaw struct {
+	Contract *UtilsCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// UtilsTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type UtilsTransactorRaw struct {
+	Contract *UtilsTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewUtils creates a new instance of Utils, bound to a specific deployed contract.
+func NewUtils(address common.Address, backend bind.ContractBackend) (*Utils, error) {
+	contract, err := bindUtils(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Utils{UtilsCaller: UtilsCaller{contract: contract}, UtilsTransactor: UtilsTransactor{contract: contract}, UtilsFilterer: UtilsFilterer{contract: contract}}, nil
+}
+
+// NewUtilsCaller creates a new read-only instance of Utils, bound to a specific deployed contract.
+func NewUtilsCaller(address common.Address, caller bind.ContractCaller) (*UtilsCaller, error) {
+	contract, err := bindUtils(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UtilsCaller{contract: contract}, nil
+}
+
+// NewUtilsTransactor creates a new write-only instance of Utils, bound to a specific deployed contract.
+func NewUtilsTransactor(address common.Address, transactor bind.ContractTransactor) (*UtilsTransactor, error) {
+	contract, err := bindUtils(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &UtilsTransactor{contract: contract}, nil
+}
+
+// NewUtilsFilterer creates a new log filterer instance of Utils, bound to a specific deployed contract.
+func NewUtilsFilterer(address common.Address, filterer bind.ContractFilterer) (*UtilsFilterer, error) {
+	contract, err := bindUtils(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &UtilsFilterer{contract: contract}, nil
+}
+
+// bindUtils binds a generic wrapper to an already deployed contract.
+func bindUtils(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(UtilsABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Utils *UtilsRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Utils.Contract.UtilsCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Utils *UtilsRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Utils.Contract.UtilsTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Utils *UtilsRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Utils.Contract.UtilsTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Utils *UtilsCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Utils.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Utils *UtilsTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Utils.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Utils *UtilsTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Utils.Contract.contract.Transact(opts, method, params...)
+}

--- a/contract/config.go
+++ b/contract/config.go
@@ -1,0 +1,25 @@
+package contract
+
+// Network is used to represent a Republic Protocol network.
+type Network string
+
+const (
+	// NetworkMainnet represents the mainnet
+	NetworkMainnet Network = "mainnet"
+	// NetworkTestnet represents the internal F∅ testnet
+	NetworkTestnet Network = "testnet"
+	// NetworkFalcon represents the internal Falcon testnet
+	NetworkFalcon Network = "falcon"
+	// NetworkNightly represents the internal Nightly testnet
+	NetworkNightly Network = "nightly"
+	// NetworkLocal represents a local network
+	NetworkLocal Network = "local"
+)
+
+// Config defines the different settings for connecting to Ethereum on
+// different Republic Protocol networks.
+type Config struct {
+	Network                    Network `json:"network"`
+	URI                        string  `json:"uri"`
+	RenExBrokerVerifierAddress string  `json:"renExBrokerVerifier"`
+}

--- a/contract/ethereum.go
+++ b/contract/ethereum.go
@@ -33,6 +33,8 @@ func Connect(config Config) (Conn, error) {
 
 	if config.RenExBrokerVerifierAddress == "" {
 		switch config.Network {
+		case NetworkFalcon:
+			config.RenExBrokerVerifierAddress = "0xb6A95aED1588bE477981dcdEacd13776570ecB3D"
 		case NetworkNightly:
 			config.RenExBrokerVerifierAddress = "0xcf2F6b4b698Cd6a6B3eb1d874a939742d15f8e7E"
 		case NetworkLocal:

--- a/contract/ethereum.go
+++ b/contract/ethereum.go
@@ -1,0 +1,53 @@
+package contract
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	ethrpc "github.com/ethereum/go-ethereum/rpc"
+)
+
+// Conn contains the client and the contracts deployed to it
+type Conn struct {
+	RawClient *ethrpc.Client
+	Client    *ethclient.Client
+	Config    Config
+}
+
+// Connect to a URI.
+func Connect(config Config) (Conn, error) {
+	if config.URI == "" {
+		switch config.Network {
+		case NetworkTestnet:
+			config.URI = "https://kovan.infura.io"
+		case NetworkFalcon:
+			config.URI = "https://kovan.infura.io"
+		case NetworkNightly:
+			config.URI = "https://kovan.infura.io"
+		case NetworkLocal:
+			config.URI = "http://localhost:8545"
+		default:
+			return Conn{}, fmt.Errorf("cannot connect to %s: unsupported", config.Network)
+		}
+	}
+
+	if config.RenExBrokerVerifierAddress == "" {
+		switch config.Network {
+		case NetworkNightly:
+			config.RenExBrokerVerifierAddress = "0x340B806594a87d87d904d641087e0c374800D00f"
+		case NetworkLocal:
+		default:
+			return Conn{}, fmt.Errorf("no default contract address on %s", config.Network)
+		}
+	}
+
+	ethclient, err := ethclient.Dial(config.URI)
+	if err != nil {
+		return Conn{}, err
+	}
+
+	return Conn{
+		Client: ethclient,
+		Config: config,
+	}, nil
+}

--- a/contract/ethereum.go
+++ b/contract/ethereum.go
@@ -34,7 +34,7 @@ func Connect(config Config) (Conn, error) {
 	if config.RenExBrokerVerifierAddress == "" {
 		switch config.Network {
 		case NetworkNightly:
-			config.RenExBrokerVerifierAddress = "0x340B806594a87d87d904d641087e0c374800D00f"
+			config.RenExBrokerVerifierAddress = "0xcf2F6b4b698Cd6a6B3eb1d874a939742d15f8e7E"
 		case NetworkLocal:
 		default:
 			return Conn{}, fmt.Errorf("no default contract address on %s", config.Network)

--- a/env/falcon/config.json
+++ b/env/falcon/config.json
@@ -5,7 +5,10 @@
         "/ip4/13.114.234.59/tcp/18514/republic/8MKKUenZG8inoZqd8boYxGb1J3waAg",
         "/ip4/35.154.181.5/tcp/18514/republic/8MJNi8mgfQqD52bjUCnUzJ64uneJbk"
     ],
-    "ethereum": {
+    "republic": {
+        "network": "falcon"
+    },
+    "renex": {
         "network": "falcon"
     }
 }

--- a/env/f∅/config.json
+++ b/env/f∅/config.json
@@ -7,7 +7,10 @@
         "/ip4/52.59.176.141/tcp/18514/republic/8MHX3awj1hj1x3XbKxq5uUuE8uQ6mq",
         "/ip4/18.228.50.197/tcp/18514/republic/8MJrKWdEmUFwZcKArzyABdYvovQQcP"
     ],
-    "ethereum": {
+    "republic": {
+        "network": "testnet"
+    },
+    "renex": {
         "network": "testnet"
     }
 }

--- a/env/nightly/config.json
+++ b/env/nightly/config.json
@@ -4,7 +4,10 @@
         "/ip4/52.62.18.91/tcp/18514/republic/8MJnjSUVJCgP6YVjNWzaJXtiKE3p1o",
         "/ip4/52.59.235.50/tcp/18514/republic/8MJJeN5VYNGqZtEiti5aZtzo7g6pgM"
     ],
-    "ethereum": {
+    "republic": {
+        "network": "nightly"
+    },
+    "renex": {
         "network": "nightly"
     }
 }

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -13,7 +13,7 @@ import (
 // NewIngressServer returns an http server that forwards requests to an
 // IngressAdapter.
 func NewIngressServer(ingressAdapter IngressAdapter) http.Handler {
-	limiter := rate.NewLimiter(20, 50)
+	limiter := rate.NewLimiter(10, 50)
 	r := mux.NewRouter().StrictSlash(true)
 	r.HandleFunc("/orders", rateLimit(limiter, OpenOrderHandler(ingressAdapter))).Methods("POST")
 	r.HandleFunc("/withdrawals", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -99,6 +99,7 @@ func GetAddressHandler(getAddressAdapter GetAddressAdapter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		addr, err := getAddressAdapter.GetAddress(params["orderID"])
+		fmt.Println("Order ID: ", params["orderID"])
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(fmt.Sprintf("cannot open order: %v", err)))

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -3,11 +3,12 @@ package httpadapter
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
+
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 	"golang.org/x/time/rate"
-	"log"
-	"net/http"
 )
 
 // NewIngressServer returns an http server that forwards requests to an

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -99,7 +99,6 @@ func GetAddressHandler(getAddressAdapter GetAddressAdapter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		params := mux.Vars(r)
 		addr, err := getAddressAdapter.GetAddress(params["orderID"])
-		fmt.Println("Order ID: ", params["orderID"])
 		if err != nil {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(fmt.Sprintf("cannot open order: %v", err)))

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -21,8 +21,8 @@ func NewIngressServer(ingressAdapter IngressAdapter) http.Handler {
 	r.HandleFunc("/withdrawals", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")
 	r.HandleFunc("/address", rateLimit(limiter, PostAddressHandler(ingressAdapter))).Methods("POST")
 	r.HandleFunc("/swap", rateLimit(limiter, PostSwapHandler(ingressAdapter))).Methods("POST")
-	r.HandleFunc("/address", rateLimit(limiter, GetAddressHandler(ingressAdapter))).Methods("GET")
-	r.HandleFunc("/swap", rateLimit(limiter, GetSwapHandler(ingressAdapter))).Methods("GET")
+	r.HandleFunc("/address/{orderID}", rateLimit(limiter, GetAddressHandler(ingressAdapter))).Methods("GET")
+	r.HandleFunc("/swap/{orderID}", rateLimit(limiter, GetSwapHandler(ingressAdapter))).Methods("GET")
 	r.Use(RecoveryHandler)
 
 	handler := cors.New(cors.Options{

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -19,10 +19,10 @@ func NewIngressServer(ingressAdapter IngressAdapter) http.Handler {
 	r := mux.NewRouter().StrictSlash(true)
 	r.HandleFunc("/orders", rateLimit(limiter, OpenOrderHandler(ingressAdapter))).Methods("POST")
 	r.HandleFunc("/withdrawals", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")
-	r.HandleFunc("/address", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")
-	r.HandleFunc("/swap", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")
-	r.HandleFunc("/address", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("GET")
-	r.HandleFunc("/swap", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("GET")
+	r.HandleFunc("/address", rateLimit(limiter, PostAddressHandler(ingressAdapter))).Methods("POST")
+	r.HandleFunc("/swap", rateLimit(limiter, PostSwapHandler(ingressAdapter))).Methods("POST")
+	r.HandleFunc("/address", rateLimit(limiter, GetAddressHandler(ingressAdapter))).Methods("GET")
+	r.HandleFunc("/swap", rateLimit(limiter, GetSwapHandler(ingressAdapter))).Methods("GET")
 	r.Use(RecoveryHandler)
 
 	handler := cors.New(cors.Options{

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -15,7 +15,7 @@ import (
 // NewIngressServer returns an http server that forwards requests to an
 // IngressAdapter.
 func NewIngressServer(ingressAdapter IngressAdapter) http.Handler {
-	limiter := rate.NewLimiter(10, 50)
+	limiter := rate.NewLimiter(5, 20)
 	r := mux.NewRouter().StrictSlash(true)
 	r.HandleFunc("/orders", rateLimit(limiter, OpenOrderHandler(ingressAdapter))).Methods("POST")
 	r.HandleFunc("/withdrawals", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -41,8 +41,18 @@ func OpenOrderHandler(openOrderAdapter OpenOrderAdapter) http.HandlerFunc {
 			w.Write([]byte(fmt.Sprintf("cannot open order: %v", err)))
 			return
 		}
+
+		response, err := json.Marshal(OpenOrderResponse{
+			Signature: MarshalSignature(signature),
+		})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(fmt.Sprintf("cannot open order: %v", err)))
+			return
+		}
+
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(MarshalSignature(signature)))
+		w.Write(response)
 	}
 }
 
@@ -61,8 +71,18 @@ func ApproveWithdrawalHandler(approveWithdrawalAdapter ApproveWithdrawalAdapter)
 			w.Write([]byte(fmt.Sprintf("cannot open order: %v", err)))
 			return
 		}
+
+		response, err := json.Marshal(ApproveWithdrawalResponse{
+			Signature: MarshalSignature(signature),
+		})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(fmt.Sprintf("cannot open order: %v", err)))
+			return
+		}
+
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(MarshalSignature(signature)))
+		w.Write(response)
 	}
 }
 

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 	"golang.org/x/time/rate"
+	"log"
 	"net/http"
 )
 
@@ -84,10 +85,14 @@ func rateLimit(limiter *rate.Limiter, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// netAddr := r.RemoteAddr
 		// ipAddr := strings.Split(netAddr, ":")[0]
+		log.Println("before rate limiting ")
 		if limiter.Allow() {
+			log.Println("allow")
 			next.ServeHTTP(w, r)
 			return
 		}
+		log.Println("not allow")
+
 		w.WriteHeader(http.StatusTooManyRequests)
 		w.Write([]byte("too many request"))
 	}

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -15,7 +15,7 @@ import (
 // NewIngressServer returns an http server that forwards requests to an
 // IngressAdapter.
 func NewIngressServer(ingressAdapter IngressAdapter) http.Handler {
-	limiter := rate.NewLimiter(5, 20)
+	limiter := rate.NewLimiter(3, 20)
 	r := mux.NewRouter().StrictSlash(true)
 	r.HandleFunc("/orders", rateLimit(limiter, OpenOrderHandler(ingressAdapter))).Methods("POST")
 	r.HandleFunc("/withdrawals", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -2,6 +2,7 @@ package httpadapter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -18,6 +19,10 @@ func NewIngressServer(ingressAdapter IngressAdapter) http.Handler {
 	r := mux.NewRouter().StrictSlash(true)
 	r.HandleFunc("/orders", rateLimit(limiter, OpenOrderHandler(ingressAdapter))).Methods("POST")
 	r.HandleFunc("/withdrawals", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")
+	r.HandleFunc("/address", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")
+	r.HandleFunc("/swap", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("POST")
+	r.HandleFunc("/address", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("GET")
+	r.HandleFunc("/swap", rateLimit(limiter, ApproveWithdrawalHandler(ingressAdapter))).Methods("GET")
 	r.Use(RecoveryHandler)
 
 	handler := cors.New(cors.Options{
@@ -69,6 +74,74 @@ func ApproveWithdrawalHandler(approveWithdrawalAdapter ApproveWithdrawalAdapter)
 	}
 }
 
+// GetAddressHandler handles all HTTP get address requests
+func GetAddressHandler(getAddressAdapter GetAddressAdapter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		addr, err := getAddressAdapter.GetAddress(params["orderID"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(fmt.Sprintf("cannot open order: %v", err)))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(addr))
+	}
+}
+
+// PostAddressHandler handles all HTTP post address requests
+func PostAddressHandler(postAddressAdapter PostAddressAdapter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		postAddressRequest := PostAddressRequest{}
+		if err := json.NewDecoder(r.Body).Decode(&postAddressRequest); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(fmt.Sprintf("cannot decode json into a trader and token: %v", err)))
+			return
+		}
+
+		if err := postAddressAdapter.PostAddress(postAddressRequest.OrderID, postAddressRequest.Address); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(fmt.Sprintf("cannot open order: %v", err)))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}
+}
+
+// GetSwapHandler handles all HTTP get swap details requests
+func GetSwapHandler(getSwapAdapter GetSwapAdapter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		swap, err := getSwapAdapter.GetSwap(params["orderID"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(fmt.Sprintf("required swap details not found: %v", err)))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(swap))
+	}
+}
+
+// PostSwapHandler handles all HTTP get swap details requests
+func PostSwapHandler(postSwapAdapter PostSwapAdapter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		postSwapRequest := PostSwapRequest{}
+		if err := json.NewDecoder(r.Body).Decode(&postSwapRequest); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(fmt.Sprintf("cannot decode json into a trader and token: %v", err)))
+			return
+		}
+
+		if err := postSwapAdapter.PostSwap(postSwapRequest.OrderID, postSwapRequest.Swap); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(fmt.Sprintf("cannot open order: %v", err)))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}
+}
+
 // RecoveryHandler handles errors while processing the requests and populates the errors in the response
 func RecoveryHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -97,4 +170,13 @@ func rateLimit(limiter *rate.Limiter, next http.HandlerFunc) http.HandlerFunc {
 		w.WriteHeader(http.StatusTooManyRequests)
 		w.Write([]byte("too many request"))
 	}
+}
+
+func toBytes32(b []byte) ([32]byte, error) {
+	bytes32 := [32]byte{}
+	if len(b) != 32 {
+		return bytes32, errors.New("Length mismatch")
+	}
+	copy(bytes32[:], b[:32])
+	return bytes32, nil
 }

--- a/httpadapter/httpadapter_test.go
+++ b/httpadapter/httpadapter_test.go
@@ -14,29 +14,29 @@ import (
 )
 
 type weakAdapter struct {
-	numOpened   int64
-	numCanceled int64
+	numOpened    int64
+	numWithdrawn int64
 }
 
-func (adapter *weakAdapter) OpenOrder(signature string, orderFragmentMapping OrderFragmentMappings) error {
+func (adapter *weakAdapter) OpenOrder(trader string, orderFragmentMapping OrderFragmentMappings) ([65]byte, error) {
 	atomic.AddInt64(&adapter.numOpened, 1)
-	return nil
+	return [65]byte{}, nil
 }
 
-func (adapter *weakAdapter) CancelOrder(signature string, orderID string) error {
-	atomic.AddInt64(&adapter.numCanceled, 1)
-	return nil
+func (adapter *weakAdapter) ApproveWithdrawal(trader string, tokenID uint32) ([65]byte, error) {
+	atomic.AddInt64(&adapter.numWithdrawn, 1)
+	return [65]byte{}, nil
 }
 
 type errAdapter struct {
 }
 
-func (adapter *errAdapter) OpenOrder(signature string, orderFragmentMapping OrderFragmentMappings) error {
-	return errors.New("cannot open order")
+func (adapter *errAdapter) OpenOrder(trader string, orderFragmentMapping OrderFragmentMappings) ([65]byte, error) {
+	return [65]byte{}, errors.New("cannot open order")
 }
 
-func (adapter *errAdapter) CancelOrder(signature string, orderID string) error {
-	return errors.New("cannot cancel order")
+func (adapter *errAdapter) ApproveWithdrawal(trader string, tokenID uint32) ([65]byte, error) {
+	return [65]byte{}, errors.New("cannot approve withdrawal")
 }
 
 var _ = Describe("HTTP handlers", func() {
@@ -88,52 +88,6 @@ var _ = Describe("HTTP handlers", func() {
 			body := bytes.NewBuffer(data)
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("POST", "http://localhost/orders", body)
-
-			adapter := errAdapter{}
-			server := NewIngressServer(&adapter)
-			server.ServeHTTP(w, r)
-
-			Expect(w.Code).To(Equal(http.StatusInternalServerError))
-		})
-	})
-
-	Context("when canceling orders", func() {
-
-		It("should return status 200 for a valid request", func() {
-
-			orderID := "vrZhWU3VV9LRIriRvuzT9CbVc57wQhbQ"
-			signature := "Td2YBy0MRYPYqqBduRmDsIhTySQUlMhPBM+wnNPWKqq="
-			w := httptest.NewRecorder()
-			r := httptest.NewRequest("DELETE", "http://localhost/orders?id="+orderID+"&signature="+signature, nil)
-
-			adapter := weakAdapter{}
-			server := NewIngressServer(&adapter)
-			server.ServeHTTP(w, r)
-
-			Expect(w.Code).To(Equal(http.StatusOK))
-			Expect(atomic.LoadInt64(&adapter.numCanceled)).To(Equal(int64(1)))
-		})
-
-		It("should return status 400 for an invalid signature", func() {
-
-			orderID := "vrZhWU3VV9LRIriRvuzT9CbVc57wQhbQ"
-			w := httptest.NewRecorder()
-			r := httptest.NewRequest("DELETE", "http://localhost/orders?id="+orderID, nil)
-
-			adapter := weakAdapter{}
-			server := NewIngressServer(&adapter)
-			server.ServeHTTP(w, r)
-
-			Expect(w.Code).To(Equal(http.StatusBadRequest))
-			Expect(atomic.LoadInt64(&adapter.numOpened)).To(Equal(int64(0)))
-		})
-
-		It("should return status 500 for ingress adapter errors", func() {
-
-			orderID := "vrZhWU3VV9LRIriRvuzT9CbVc57wQhbQ"
-			signature := "Td2YBy0MRYPYqqBduRmDsIhTySQUlMhPBM+wnNPWKqq="
-			w := httptest.NewRecorder()
-			r := httptest.NewRequest("DELETE", "http://localhost/orders?id="+orderID+"&signature="+signature, nil)
 
 			adapter := errAdapter{}
 			server := NewIngressServer(&adapter)

--- a/httpadapter/httpadapter_test.go
+++ b/httpadapter/httpadapter_test.go
@@ -60,6 +60,12 @@ var _ = Describe("HTTP handlers", func() {
 			server.ServeHTTP(w, r)
 
 			Expect(w.Code).To(Equal(http.StatusCreated))
+
+			var response OpenOrderResponse
+			err = json.Unmarshal(w.Body.Bytes(), &response)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(UnmarshalSignature(response.Signature)).To(Equal(WEAK_SIGNATURE))
+
 			Expect(atomic.LoadInt64(&adapter.numOpened)).To(Equal(int64(1)))
 		})
 
@@ -116,7 +122,12 @@ var _ = Describe("HTTP handlers", func() {
 			server.ServeHTTP(w, r)
 
 			Expect(w.Code).To(Equal(http.StatusCreated))
-			Expect(UnmarshalSignature(w.Body.String())).To(Equal(WEAK_SIGNATURE))
+
+			var response ApproveWithdrawalResponse
+			err = json.Unmarshal(w.Body.Bytes(), &response)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(UnmarshalSignature(response.Signature)).To(Equal(WEAK_SIGNATURE))
+
 			Expect(atomic.LoadInt64(&adapter.numWithdrawn)).To(Equal(int64(1)))
 		})
 

--- a/httpadapter/ingress.go
+++ b/httpadapter/ingress.go
@@ -49,11 +49,31 @@ type ApproveWithdrawalAdapter interface {
 	ApproveWithdrawal(traderIn string, tokenID uint32) ([65]byte, error)
 }
 
+type GetAddressAdapter interface {
+	GetAddress(string) (string, error)
+}
+
+type PostAddressAdapter interface {
+	PostAddress(string, string) error
+}
+
+type GetSwapAdapter interface {
+	GetSwap(string) (string, error)
+}
+
+type PostSwapAdapter interface {
+	PostSwap(string, string) error
+}
+
 // An IngressAdapter implements the OpenOrderAdapter and the
 // ApproveWithdrawalAdapter.
 type IngressAdapter interface {
 	OpenOrderAdapter
 	ApproveWithdrawalAdapter
+	GetAddressAdapter
+	PostAddressAdapter
+	GetSwapAdapter
+	PostSwapAdapter
 }
 
 type ingressAdapter struct {
@@ -98,4 +118,20 @@ func (adapter *ingressAdapter) ApproveWithdrawal(traderIn string, tokenIDIn uint
 		trader,
 		tokenIDIn,
 	)
+}
+
+func (adapter *ingressAdapter) GetAddress(orderID string) (string, error) {
+	return adapter.SelectAddress(orderID)
+}
+
+func (adapter *ingressAdapter) PostAddress(orderID string, address string) error {
+	return adapter.InsertAddress(orderID, address)
+}
+
+func (adapter *ingressAdapter) GetSwap(orderID string) (string, error) {
+	return adapter.SelectSwapDetails(orderID)
+}
+
+func (adapter *ingressAdapter) PostSwap(orderID string, swap string) error {
+	return adapter.InsertSwapDetails(orderID, swap)
 }

--- a/httpadapter/ingress_test.go
+++ b/httpadapter/ingress_test.go
@@ -3,6 +3,7 @@ package httpadapter_test
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	mathRand "math/rand"
 	"sync/atomic"
 	"time"
@@ -167,7 +168,7 @@ var _ = Describe("Ingress Adapter", func() {
 			traderBytes := [20]byte{}
 			_, err := rand.Read(traderBytes[:])
 			Expect(err).ShouldNot(HaveOccurred())
-			trader := base64.StdEncoding.EncodeToString(traderBytes[:])
+			trader := hex.EncodeToString(traderBytes[:])
 
 			orderFragmentMappingIn := OrderFragmentMapping{}
 			orderFragmentMappingIn["Td2YBy0MRYPYqqBduRmDsIhTySQUlMhPBM+wnNPWKqq="] = []OrderFragment{}
@@ -201,7 +202,7 @@ var _ = Describe("Ingress Adapter", func() {
 			traderBytes := [20]byte{}
 			_, err := rand.Read(traderBytes[:])
 			Expect(err).ShouldNot(HaveOccurred())
-			trader := base64.StdEncoding.EncodeToString(traderBytes[:])
+			trader := hex.EncodeToString(traderBytes[:])
 			orderFragmentMappingIn := OrderFragmentMapping{}
 			orderFragmentMappingIn["some invalid hash"] = []OrderFragment{OrderFragment{OrderID: "thisIsAnOrderID"}}
 
@@ -223,7 +224,7 @@ var _ = Describe("Ingress Adapter", func() {
 			traderBytes := [20]byte{}
 			_, err := rand.Read(traderBytes[:])
 			Expect(err).ShouldNot(HaveOccurred())
-			trader := base64.StdEncoding.EncodeToString(traderBytes[:])
+			trader := hex.EncodeToString(traderBytes[:])
 
 			_, err = ingressAdapter.ApproveWithdrawal(trader, 0)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -268,8 +269,6 @@ func (ingress *mockIngress) ProcessRequests(done <-chan struct{}) <-chan error {
 
 func createOrder() (order.Order, error) {
 	parity := order.ParityBuy
-	price := uint64(mathRand.Intn(2000))
-	volume := uint64(mathRand.Intn(2000))
 	nonce := uint64(mathRand.Intn(1000000000))
-	return order.NewOrder(order.TypeLimit, parity, order.SettlementRenEx, time.Now().Add(time.Hour), order.TokensETHREN, order.NewCoExp(price, 26), order.NewCoExp(volume, 26), order.NewCoExp(volume, 26), nonce), nil
+	return order.NewOrder(parity, order.TypeLimit, time.Now().Add(time.Hour), order.SettlementRenEx, order.TokensETHREN, 1, 1, 1, nonce), nil
 }

--- a/httpadapter/ingress_test.go
+++ b/httpadapter/ingress_test.go
@@ -270,5 +270,5 @@ func (ingress *mockIngress) ProcessRequests(done <-chan struct{}) <-chan error {
 func createOrder() (order.Order, error) {
 	parity := order.ParityBuy
 	nonce := uint64(mathRand.Intn(1000000000))
-	return order.NewOrder(parity, order.TypeLimit, time.Now().Add(time.Hour), order.SettlementRenEx, order.TokensETHREN, 1, 1, 1, nonce), nil
+	return order.NewOrder(parity, order.TypeLimit, time.Now().Add(time.Hour), order.SettlementRenEx, order.TokensETHREN, 1e12, 1e12, 1e12, nonce), nil
 }

--- a/httpadapter/marshal.go
+++ b/httpadapter/marshal.go
@@ -78,7 +78,7 @@ func MarshalSignature(signatureIn [65]byte) string {
 	return base64.StdEncoding.EncodeToString(signatureIn[:])
 }
 
-func MarshalAddress(addressIn [32]byte) string {
+func MarshalAddress(addressIn [20]byte) string {
 	return hex.EncodeToString(addressIn[:])
 }
 
@@ -129,6 +129,12 @@ func UnmarshalSignature(signatureIn string) ([65]byte, error) {
 
 func UnmarshalAddress(addressIn string) ([20]byte, error) {
 	address := [20]byte{}
+	// If the address starts with "0x", remove before decoding
+	if len(addressIn) > 1 {
+		if addressIn[0:2] == "0x" || addressIn[0:2] == "0X" {
+			addressIn = addressIn[2:]
+		}
+	}
 	addressBytes, err := hex.DecodeString(addressIn)
 	if err != nil {
 		return address, fmt.Errorf("cannot decode address %v: %v", addressIn, err)

--- a/httpadapter/marshal.go
+++ b/httpadapter/marshal.go
@@ -56,6 +56,16 @@ type ApproveWithdrawalRequest struct {
 	TokenID uint32 `json:"tokenID"`
 }
 
+type PostAddressRequest struct {
+	OrderID string `json:"orderID"`
+	Address string `json:"address"`
+}
+
+type PostSwapRequest struct {
+	OrderID string `json:"orderID"`
+	Swap    string `json:"swap"`
+}
+
 func MarshalSignature(signatureIn [65]byte) string {
 	return base64.StdEncoding.EncodeToString(signatureIn[:])
 }

--- a/httpadapter/marshal.go
+++ b/httpadapter/marshal.go
@@ -49,11 +49,19 @@ type OpenOrderRequest struct {
 	OrderFragmentMappings OrderFragmentMappings `json:"orderFragmentMappings"`
 }
 
+type OpenOrderResponse struct {
+	Signature string `json:"signature"`
+}
+
 // ApproveWithdrawalRequest is an JSON object sent to the HTTP handlers to
 // request the approval of a withdrawal.
 type ApproveWithdrawalRequest struct {
-	Trader  string `json:"trader"`
+	Trader  string `json:"address"`
 	TokenID uint32 `json:"tokenID"`
+}
+
+type ApproveWithdrawalResponse struct {
+	Signature string `json:"signature"`
 }
 
 func MarshalSignature(signatureIn [65]byte) string {

--- a/httpadapter/marshal.go
+++ b/httpadapter/marshal.go
@@ -3,6 +3,7 @@ package httpadapter
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -60,7 +61,7 @@ func MarshalSignature(signatureIn [65]byte) string {
 }
 
 func MarshalAddress(addressIn [32]byte) string {
-	return base64.StdEncoding.EncodeToString(addressIn[:])
+	return hex.EncodeToString(addressIn[:])
 }
 
 func MarshalOrderID(orderIDIn order.ID) string {
@@ -110,7 +111,7 @@ func UnmarshalSignature(signatureIn string) ([65]byte, error) {
 
 func UnmarshalAddress(addressIn string) ([20]byte, error) {
 	address := [20]byte{}
-	addressBytes, err := base64.StdEncoding.DecodeString(addressIn)
+	addressBytes, err := hex.DecodeString(addressIn)
 	if err != nil {
 		return address, fmt.Errorf("cannot decode address %v: %v", addressIn, err)
 	}

--- a/httpadapter/marshal.go
+++ b/httpadapter/marshal.go
@@ -15,7 +15,6 @@ import (
 // in the OrderFragment. It is represented as a JSON object. This
 // representation is useful for HTTP drivers.
 type OrderFragment struct {
-	OrderSignature  string           `json:"orderSignature"`
 	OrderID         string           `json:"orderId"`
 	OrderType       order.Type       `json:"orderType"`
 	OrderParity     order.Parity     `json:"orderParity"`
@@ -45,12 +44,23 @@ type OrderFragmentMappings []OrderFragmentMapping
 // OpenOrderRequest is an JSON object sent to the HTTP handlers to request the
 // opening of an order.
 type OpenOrderRequest struct {
-	Signature             string                `json:"signature"`
+	Address               string                `json:"address"`
 	OrderFragmentMappings OrderFragmentMappings `json:"orderFragmentMappings"`
+}
+
+// ApproveWithdrawalRequest is an JSON object sent to the HTTP handlers to
+// request the approval of a withdrawal.
+type ApproveWithdrawalRequest struct {
+	Trader  string `json:"trader"`
+	TokenID uint32 `json:"tokenID"`
 }
 
 func MarshalSignature(signatureIn [65]byte) string {
 	return base64.StdEncoding.EncodeToString(signatureIn[:])
+}
+
+func MarshalAddress(addressIn [32]byte) string {
+	return base64.StdEncoding.EncodeToString(addressIn[:])
 }
 
 func MarshalOrderID(orderIDIn order.ID) string {
@@ -96,6 +106,19 @@ func UnmarshalSignature(signatureIn string) ([65]byte, error) {
 	}
 	copy(signature[:], signatureBytes)
 	return signature, nil
+}
+
+func UnmarshalAddress(addressIn string) ([20]byte, error) {
+	address := [20]byte{}
+	addressBytes, err := base64.StdEncoding.DecodeString(addressIn)
+	if err != nil {
+		return address, fmt.Errorf("cannot decode address %v: %v", addressIn, err)
+	}
+	if len(addressBytes) != 20 {
+		return address, ErrInvalidAddressLength
+	}
+	copy(address[:], addressBytes)
+	return address, nil
 }
 
 func UnmarshalOrderID(orderIDIn string) (order.ID, error) {

--- a/ingress/contract.go
+++ b/ingress/contract.go
@@ -3,18 +3,17 @@ package ingress
 import (
 	"math/big"
 
-	"github.com/republicprotocol/republic-go/order"
 	"github.com/republicprotocol/republic-go/registry"
 )
 
 // ContractBinder will define all methods that the ingress will require to
 // communicate with smart contracts.
 type ContractBinder interface {
-	OpenBuyOrder(signature [65]byte, orderID order.ID) error
+	// OpenBuyOrder(signature [65]byte, orderID order.ID) error
 
-	OpenSellOrder(signature [65]byte, orderID order.ID) error
+	// OpenSellOrder(signature [65]byte, orderID order.ID) error
 
-	CancelOrder(signature [65]byte, orderID order.ID) error
+	// CancelOrder(signature [65]byte, orderID order.ID) error
 
 	MinimumEpochInterval() (*big.Int, error)
 
@@ -27,6 +26,4 @@ type ContractBinder interface {
 	Pods() ([]registry.Pod, error)
 
 	PreviousPods() ([]registry.Pod, error)
-
-	CurrentBlockNumber() (*big.Int, error)
 }

--- a/ingress/contract.go
+++ b/ingress/contract.go
@@ -3,6 +3,7 @@ package ingress
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/republicprotocol/republic-go/registry"
 )
 
@@ -20,4 +21,8 @@ type ContractBinder interface {
 	Pods() ([]registry.Pod, error)
 
 	PreviousPods() ([]registry.Pod, error)
+}
+
+type RenExContractBinder interface {
+	GetTraderWithdrawalNonce(trader common.Address) (*big.Int, error)
 }

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -41,22 +41,6 @@ var ErrInvalidNumberOfOrderFragments = errors.New("invalid number of order fragm
 // of an invalid length.
 var ErrInvalidOrderFragmentMapping = errors.New("invalid order fragment mappings")
 
-// ErrOrderFragmentIsNil is returned when a nil orderFragment is provided
-// upon verification.
-var ErrOrderFragmentIsNil = errors.New("order fragment is nil")
-
-// ErrMultiAddressIsNil is returned when a nil multi-address is detected.
-var ErrMultiAddressIsNil = errors.New("multi-address is nil")
-
-// ErrEpochIsNil is returned when a nil epoch is detected.
-var ErrEpochIsNil = errors.New("epoch is nil")
-
-// ErrOpenOrderRequestIsNil is returned when a nil OpenOrderRequest is detected.
-var ErrOpenOrderRequestIsNil = errors.New("OpenOrderRequest is nil")
-
-// ErrOrderFragmentMappingRequestIsNil is returned when a nil OrderFragmentMappingRequest is detected.
-var ErrOrderFragmentMappingRequestIsNil = errors.New("OrderFragmentMappingRequest is nil")
-
 // ErrInvalidEpochDepth is returned when an invalid epoch depth is provided
 // upon verification.
 var ErrInvalidEpochDepth = errors.New("invalid epoch depth")
@@ -150,11 +134,7 @@ func (ingress *ingress) Sync(done <-chan struct{}) <-chan error {
 		close(errs)
 		return errs
 	}
-	if epoch.IsNil() {
-		errs <- ErrEpochIsNil
-		close(errs)
-		return errs
-	}
+
 	pods, err := ingress.contract.PreviousPods()
 	if err != nil {
 		errs <- err
@@ -191,10 +171,6 @@ func (ingress *ingress) Sync(done <-chan struct{}) <-chan error {
 						case errs <- err:
 							continue
 						}
-					}
-
-					if nextEpoch.IsNil() {
-						continue
 					}
 
 					// Check if it equals what we think the current epoch is
@@ -349,10 +325,6 @@ func (ingress *ingress) processRequestQueue(done <-chan struct{}, errs chan<- er
 }
 
 func (ingress *ingress) processOpenOrderFragmentMappingRequest(req OpenOrderFragmentMappingRequest, done <-chan struct{}, errs chan<- error) {
-	if req.IsNil() {
-		errs <- ErrOrderFragmentMappingRequestIsNil
-		return
-	}
 	ingress.podsMu.RLock()
 	defer ingress.podsMu.RUnlock()
 
@@ -421,10 +393,6 @@ func (ingress *ingress) sendOrderFragmentsToPod(pod registry.Pod, orderFragments
 				errs <- fmt.Errorf("no fragment found at index %v", i)
 				return
 			}
-			if orderFragment.IsNil() || orderFragment.EncryptedFragment.IsNil() {
-				errs <- fmt.Errorf("invalid order fragment found at index %v", i)
-				return
-			}
 
 			darknode := pod.Darknodes[i]
 
@@ -440,11 +408,6 @@ func (ingress *ingress) sendOrderFragmentsToPod(pod registry.Pod, orderFragments
 			darknodeMultiAddr, err := ingress.swarmer.Query(ctx, darknode)
 			if err != nil {
 				errs <- fmt.Errorf("cannot send query to %v: %v", darknode, err)
-				return
-			}
-
-			if darknodeMultiAddr.IsNil() {
-				errs <- ErrMultiAddressIsNil
 				return
 			}
 
@@ -523,9 +486,6 @@ func (ingress *ingress) verifyOrderFragmentMapping(orderFragmentMapping OrderFra
 		// Ensure order fragment Epoch depth matches up with value provided as
 		// parameter.
 		for _, orderFragment := range orderFragments {
-			if orderFragment.IsNil() {
-				return ErrOrderFragmentIsNil
-			}
 			if orderFragment.EpochDepth != order.FragmentEpochDepth(orderFragmentEpochDepth) {
 				return ErrInvalidEpochDepth
 			}

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -323,7 +323,6 @@ func (ingress *ingress) ApproveWithdrawal(trader [20]byte, tokenID uint32) ([65]
 	if err != nil {
 		return [65]byte{}, err
 	}
-	fmt.Println("trader:", common.BytesToAddress(trader[:]).Hex(), "traderNonce:", traderNonce)
 
 	message, err := WithdrawalMessage(trader, tokenID, traderNonce)
 	if err != nil {

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -323,6 +323,7 @@ func (ingress *ingress) ApproveWithdrawal(trader [20]byte, tokenID uint32) ([65]
 	if err != nil {
 		return [65]byte{}, err
 	}
+	fmt.Println("trader:", common.BytesToAddress(trader[:]).Hex(), "traderNonce:", traderNonce)
 
 	message, err := WithdrawalMessage(trader, tokenID, traderNonce)
 	if err != nil {

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -90,6 +90,9 @@ type Ingress interface {
 	// all processing. Running this background worker is required to open and
 	// cancel orders.
 	ProcessRequests(done <-chan struct{}) <-chan error
+
+	// Swapper interface implements atomic swapper network functions.
+	Swapper
 }
 
 type ingress struct {
@@ -105,17 +108,19 @@ type ingress struct {
 	podsPrev map[[32]byte]registry.Pod
 
 	queueRequests chan Request
+	Swapper
 }
 
 // NewIngress returns an Ingress. The background services of the Ingress must
 // be started separately by calling Ingress.OpenOrderProcess and
 // Ingress.OpenOrderFragmentsProcess.
-func NewIngress(ecdsaKey crypto.EcdsaKey, contract ContractBinder, renExContract RenExContractBinder, swarmer swarm.Swarmer, orderbookClient orderbook.Client, epochPollInterval time.Duration) Ingress {
+func NewIngress(ecdsaKey crypto.EcdsaKey, contract ContractBinder, renExContract RenExContractBinder, swarmer swarm.Swarmer, orderbookClient orderbook.Client, epochPollInterval time.Duration, swapper Swapper) Ingress {
 	ingress := &ingress{
 		ecdsaKey:          ecdsaKey,
 		contract:          contract,
 		renExContract:     renExContract,
 		swarmer:           swarmer,
+		Swapper:           swapper,
 		orderbookClient:   orderbookClient,
 		epochPollInterval: epochPollInterval,
 

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Ingress", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		contract = newIngressBinder()
+		// renExContract =
 
 		swarmer := mockSwarmer{}
 		orderbookClient := mockOrderbookClient{}

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -434,7 +434,7 @@ func (binder *ingressBinder) setOrderStatus(orderID order.ID, status order.Statu
 func createOrder() (order.Order, error) {
 	parity := order.ParityBuy
 	nonce := uint64(mathRand.Intn(1000000000))
-	return order.NewOrder(parity, order.TypeLimit, time.Now().Add(time.Hour), order.SettlementRenEx, order.TokensETHREN, 1, 1, 1, nonce), nil
+	return order.NewOrder(parity, order.TypeLimit, time.Now().Add(time.Hour), order.SettlementRenEx, order.TokensETHREN, 1e12, 1e12, 1e12, nonce), nil
 }
 
 type mockSwarmer struct {

--- a/ingress/request.go
+++ b/ingress/request.go
@@ -25,11 +25,6 @@ type OpenOrderFragmentMappingRequest struct {
 // IsRequest implements the Request interface.
 func (req OpenOrderFragmentMappingRequest) IsRequest() {}
 
-// IsNil returns true if the OpenOrderFragmentMappingRequest contains nil fields
-func (req *OpenOrderFragmentMappingRequest) IsNil() bool {
-	return req == nil || len(req.orderID) != 32 || len(req.orderFragmentMapping) == 0
-}
-
 type WithdrawalRequest struct {
 	trader  [20]byte
 	tokenID uint32
@@ -38,7 +33,3 @@ type WithdrawalRequest struct {
 // IsRequest implements the Request interface.
 func (req WithdrawalRequest) IsRequest() {}
 
-// IsNil returns true if the OpenOrderFragmentMappingRequest contains nil fields
-func (req *WithdrawalRequest) IsNil() bool {
-	return req == nil || len(req.trader) != 29
-}

--- a/ingress/request.go
+++ b/ingress/request.go
@@ -1,6 +1,8 @@
 package ingress
 
-import "github.com/republicprotocol/republic-go/order"
+import (
+	"github.com/republicprotocol/republic-go/order"
+)
 
 // Request is an interface implemented by components that can be interpreted by
 // an Ingress as a request for an action to be performed, usually involving the
@@ -12,21 +14,9 @@ type Request interface {
 	IsRequest()
 }
 
-// An OpenOrderRequest is a Request for the Ingress to open an order.Order on
-// the Ethereum blockchain.
-type OpenOrderRequest struct {
-	signature   [65]byte
-	orderID     order.ID
-	orderParity order.Parity
-}
-
-// IsRequest implements the Request interface.
-func (req OpenOrderRequest) IsRequest() {}
-
 // An OpenOrderFragmentMappingRequest is a Request for the Ingress to open an
 // order.Order by forwarding order.Fragments to their respective Darknodes.
 type OpenOrderFragmentMappingRequest struct {
-	signature               [65]byte
 	orderID                 order.ID
 	orderFragmentMapping    OrderFragmentMapping
 	orderFragmentEpochDepth int
@@ -35,12 +25,10 @@ type OpenOrderFragmentMappingRequest struct {
 // IsRequest implements the Request interface.
 func (req OpenOrderFragmentMappingRequest) IsRequest() {}
 
-// A CancelOrderRequest is a Request for the Ingress to cancel an order.Order
-// on the Ethereum blockchain.
-type CancelOrderRequest struct {
-	signature [65]byte
-	orderID   order.ID
+type WithdrawalRequest struct {
+	trader  [20]byte
+	tokenID uint32
 }
 
 // IsRequest implements the Request interface.
-func (req CancelOrderRequest) IsRequest() {}
+func (req WithdrawalRequest) IsRequest() {}

--- a/ingress/swapper.go
+++ b/ingress/swapper.go
@@ -27,7 +27,7 @@ func NewSwapper(databaseURL string) (Swapper, error) {
 
 func (swapper *swapper) SelectAddress(orderID string) (string, error) {
 	var address string
-	if err := swapper.QueryRow("select address from swaps where orderID = $1", orderID).Scan(&address); err != nil {
+	if err := swapper.QueryRow("SELECT address FROM swaps WHERE orderID = $1", orderID).Scan(&address); err != nil {
 		return address, err
 	}
 	if address == "" {
@@ -37,13 +37,13 @@ func (swapper *swapper) SelectAddress(orderID string) (string, error) {
 }
 
 func (swapper *swapper) InsertAddress(orderID string, address string) error {
-	_, err := swapper.Exec("INSERT INTO swaps(orderID, address) VALUES($1,$2)", orderID, address)
+	_, err := swapper.Exec("INSERT INTO swaps (orderID, address) VALUES ($1,$2)", orderID, address)
 	return err
 }
 
 func (swapper *swapper) SelectSwapDetails(orderID string) (string, error) {
 	var swapDetails string
-	if err := swapper.QueryRow("select swapDetails from swaps where orderID = $1", orderID).Scan(&swapDetails); err != nil {
+	if err := swapper.QueryRow("SELECT swapDetails FROM swaps WHERE orderID = $1", orderID).Scan(&swapDetails); err != nil {
 		return "", err
 	}
 	if swapDetails == "" {
@@ -53,6 +53,6 @@ func (swapper *swapper) SelectSwapDetails(orderID string) (string, error) {
 }
 
 func (swapper *swapper) InsertSwapDetails(orderID string, swapDetails string) error {
-	_, err := swapper.Exec("INSERT INTO swaps(orderID, swapDetails) VALUES($1,$2)", orderID, swapDetails)
+	_, err := swapper.Exec("INSERT INTO swaps (orderID, swapDetails) VALUES ($1,$2)", orderID, swapDetails)
 	return err
 }

--- a/ingress/swapper.go
+++ b/ingress/swapper.go
@@ -27,6 +27,7 @@ func NewSwapper(databaseURL string) (Swapper, error) {
 
 func (swapper *swapper) SelectAddress(orderID string) (string, error) {
 	var address string
+	fmt.Println("Address", orderID)
 	if err := swapper.QueryRow("SELECT address FROM swaps WHERE orderID = $1", orderID).Scan(&address); err != nil {
 		return address, err
 	}

--- a/ingress/swapper.go
+++ b/ingress/swapper.go
@@ -27,7 +27,6 @@ func NewSwapper(databaseURL string) (Swapper, error) {
 
 func (swapper *swapper) SelectAddress(orderID string) (string, error) {
 	var address string
-	fmt.Println("Address", orderID)
 	if err := swapper.QueryRow("SELECT address FROM swaps WHERE orderID = $1", orderID).Scan(&address); err != nil {
 		return address, err
 	}

--- a/ingress/swapper.go
+++ b/ingress/swapper.go
@@ -1,0 +1,58 @@
+package ingress
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/lib/pq"
+)
+
+type Swapper interface {
+	SelectAddress(orderID string) (string, error)
+	InsertAddress(orderID string, address string) error
+	SelectSwapDetails(orderID string) (string, error)
+	InsertSwapDetails(orderID string, swapDetails string) error
+}
+
+type swapper struct {
+	*sql.DB
+}
+
+func NewSwapper(databaseURL string) (Swapper, error) {
+	db, err := sql.Open("postgres", databaseURL)
+	return &swapper{
+		db,
+	}, err
+}
+
+func (swapper *swapper) SelectAddress(orderID string) (string, error) {
+	var address string
+	if err := swapper.QueryRow("select address from swaps where orderID = $1", orderID).Scan(&address); err != nil {
+		return address, err
+	}
+	if address == "" {
+		return address, fmt.Errorf("Requested address not found")
+	}
+	return address, nil
+}
+
+func (swapper *swapper) InsertAddress(orderID string, address string) error {
+	_, err := swapper.Exec("INSERT INTO swaps(orderID, address) VALUES($1,$2)", orderID, address)
+	return err
+}
+
+func (swapper *swapper) SelectSwapDetails(orderID string) (string, error) {
+	var swapDetails string
+	if err := swapper.QueryRow("select swapDetails from swaps where orderID = $1", orderID).Scan(&swapDetails); err != nil {
+		return "", err
+	}
+	if swapDetails == "" {
+		return swapDetails, fmt.Errorf("Requested swap details not found")
+	}
+	return swapDetails, nil
+}
+
+func (swapper *swapper) InsertSwapDetails(orderID string, swapDetails string) error {
+	_, err := swapper.Exec("INSERT INTO swaps(orderID, swapDetails) VALUES($1,$2)", orderID, swapDetails)
+	return err
+}


### PR DESCRIPTION
**Description**:

This PR updates the `POST /orders` Ingress end-point to return a signature instead of submitting the order directly to the Orderbook contract, and introduces the `POST /withdrawals` to approve balance withdrawals from the RenExBalances contract.

`DELETE /orders` has been removed - traders must now cancel orders through the Orderbook contract directly.

**Motivation**:

Requiring the trader to submit the Ethereum transactions reduces the cost and effort to maintain the Ingress.

Adding the withdrawal signature allows the Ingress to prevent traders from withdrawing balances while they have orders open for the relevant tokens.