### PR TITLE
RenEx user referral payment tracking

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -295,6 +295,25 @@
 
 [[projects]]
   branch = "nightly"
+  digest = "1:78c25ce6307f12046f6e40fe0f9437e36c849e6becc42ad40ad5bda4da8cd463"
+  name = "github.com/republicprotocol/renex-sdk-go"
+  packages = [
+    ".",
+    "adapter/bindings",
+    "adapter/client",
+    "adapter/funds",
+    "adapter/leveldb",
+    "adapter/orderbook",
+    "adapter/store",
+    "adapter/trader",
+    "core/funds",
+    "core/orderbook",
+  ]
+  pruneopts = "T"
+  revision = "c25908fdac501fb53d936ac24f40bf6b6d3fffdc"
+
+[[projects]]
+  branch = "nightly"
   digest = "1:1d529724345100992b36828cb6b2b19a7d285e260cb45f13e3f6b4175308dc2d"
   name = "github.com/republicprotocol/republic-go"
   packages = [
@@ -555,6 +574,7 @@
     "github.com/lib/pq",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
+    "github.com/republicprotocol/renex-sdk-go",
     "github.com/republicprotocol/republic-go/contract",
     "github.com/republicprotocol/republic-go/crypto",
     "github.com/republicprotocol/republic-go/dispatch",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,11 +22,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:05e21a7d7c3058ac655d1fadd968cc1268ef8c77782415227df1f3a1118a2868"
+  digest = "1:6249a43b8aca2813f1717fc170ca13fe57ac963b3493593360afa850feb612f9"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
   pruneopts = "T"
-  revision = "3dcf298fed2d5fd65918dc560b3942b2aa0629e8"
+  revision = "b6c71b40a82170695049917527b460e796d33ed7"
 
 [[projects]]
   digest = "1:fed1f537c2f1269fe475a8556c393fe466641682d73ef8fd0491cd3aa1e47bad"
@@ -92,7 +92,7 @@
   packages = ["."]
   pruneopts = "T"
   revision = "f04e7487e9a6b9d9837d52743fb5f40576c56411"
-  version = "v0.1.1"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
@@ -306,11 +306,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2bb44ad552934f1b356396b41030db8e14369a07f326a542512c2a67a423279a"
+  digest = "1:8dfea5038a19f107c1c63edc494e01265de6933f98ffa35efe2fa4eb58d06ce6"
   name = "github.com/republicprotocol/beth-go"
   packages = ["."]
   pruneopts = "T"
-  revision = "c6cabe0b3e3f9dd71eba66bc90ddb9e535d50324"
+  revision = "46378ac3c8faa4a36850e6ee999353bd1ed1ea26"
 
 [[projects]]
   branch = "master"
@@ -432,7 +432,7 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
+  revision = "fae4c4e3ad76c295c3d6d259f898136b4bf833a8"
 
 [[projects]]
   branch = "master"
@@ -557,12 +557,12 @@
   revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
-  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
+  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "T"
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,19 +3,19 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:495c7006c2f48b705f0d89fd8449a2ae70622bb748788d9d17caafa65a6769f9"
+  digest = "1:c1a6eac1aa52b62daff552d5bd043453a8675b7f9eee0ea924ed7b00a5a56264"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
   pruneopts = "T"
-  revision = "33151c4543a79b013e8e6799ef45b2ba88c3cd1c"
+  revision = "5faa74ffbed7096292069fdcd0eae96146a3158a"
 
 [[projects]]
   branch = "master"
-  digest = "1:0bd9f11575e82b723837f50e170d010ec29a50aa8ca02a962c439146f03aea55"
+  digest = "1:05e21a7d7c3058ac655d1fadd968cc1268ef8c77782415227df1f3a1118a2868"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
   pruneopts = "T"
-  revision = "67e573d211ace594f1366b4ce9d39726c4b19bd0"
+  revision = "3dcf298fed2d5fd65918dc560b3942b2aa0629e8"
 
 [[projects]]
   digest = "1:fed1f537c2f1269fe475a8556c393fe466641682d73ef8fd0491cd3aa1e47bad"
@@ -34,7 +34,7 @@
   version = "v1.7.1"
 
 [[projects]]
-  digest = "1:08af77c41dc6a9ab5dd123ce76356fa4068d57287c060cdc934e1131973dd037"
+  digest = "1:f08158538fb9b5acf86edbf06d0eafd13aafa3277abe534a01f0e99d394e4637"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -72,8 +72,8 @@
     "trie",
   ]
   pruneopts = "T"
-  revision = "8bbe72075e4e16442c4e28d999edee12e294329e"
-  version = "v1.8.17"
+  revision = "58632d44021bf095b43a1bb2443e6e3690a94739"
+  version = "v1.8.18"
 
 [[projects]]
   digest = "1:20e98cc6b7562b472ad307523dd105a0324793a7de09abe9453acefd51821f11"
@@ -114,12 +114,12 @@
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
-  digest = "1:3a26588bc48b96825977c1b3df964f8fd842cd6860cc26370588d3563433cf11"
+  digest = "1:236d7e1bdb50d8f68559af37dbcf9d142d56b431c9b2176d41e2a009b664cda8"
   name = "github.com/google/uuid"
   packages = ["."]
   pruneopts = "T"
-  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
-  version = "v1.0.0"
+  revision = "9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
@@ -215,22 +215,22 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d8fb99f78aa19805f60a9053955e109d04ca8d2d09ad5f446bc73278134e4c59"
+  digest = "1:5f2e8ff824a34750030d3837a012aa92f4099d0ba9a8e1bc4f4ef3b7a65a2944"
   name = "github.com/multiformats/go-multiaddr"
   packages = ["."]
   pruneopts = "T"
-  revision = "393301199b4437234bd500b78bdf9555f6428c18"
+  revision = "ec8630b6b7436b5d7f6c1c2366d3d7214d1b29e2"
 
 [[projects]]
   branch = "master"
-  digest = "1:4f954dbe8c79513340117e933b511f85ab673ee4c5fa881652d2a2c1f3add716"
+  digest = "1:0f57c95b11b2d915bb6c36f94a2ee9478e1afe632602a147ae7f87f1affda314"
   name = "github.com/multiformats/go-multihash"
   packages = ["."]
   pruneopts = "T"
-  revision = "97cdb562a04c6ef66d8ed40cd62f8fbcddd396d6"
+  revision = "a91e75d03bf4dba801af7b159c8b2aa7b5f47ea8"
 
 [[projects]]
-  digest = "1:99ec7b4370b05816679fe9ae77f1f8af4eae3df0abaeef8c3d2d42d86f55f549"
+  digest = "1:1de2ef6996903caab4bcf41f7885aa276d8e20076ba52ca80b2c6c32efb9c5f5"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -253,11 +253,11 @@
     "types",
   ]
   pruneopts = "T"
-  revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
-  version = "v1.6.0"
+  revision = "2e1be8f7d90e9d3e3e58b0ce470f2f14d075406f"
+  version = "v1.7.0"
 
 [[projects]]
-  digest = "1:8dd7bb91b515b86408de9c0d553f14e97ffa21c65c643976242e63d11a28999a"
+  digest = "1:4f40f5e1925c58d5f9b6a953d1b02f475a6be704e9b5f1a21df6c62c434bde13"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -274,8 +274,8 @@
     "types",
   ]
   pruneopts = "T"
-  revision = "7615b9433f86a8bdf29709bf288bc4fd0636a369"
-  version = "v1.4.2"
+  revision = "65fb64232476ad9046e57c26cd0bff3d3a8dc6cd"
+  version = "v1.4.3"
 
 [[projects]]
   digest = "1:e5d0bd87abc2781d14e274807a470acd180f0499f8bf5bb18606e9ec22ad9de9"
@@ -295,7 +295,7 @@
 
 [[projects]]
   branch = "nightly"
-  digest = "1:78c25ce6307f12046f6e40fe0f9437e36c849e6becc42ad40ad5bda4da8cd463"
+  digest = "1:d4f50500629c3ffcc0e12ff8868e3e32ac80a49e3f00a808840befcf98dbb5ab"
   name = "github.com/republicprotocol/renex-sdk-go"
   packages = [
     ".",
@@ -310,11 +310,11 @@
     "core/orderbook",
   ]
   pruneopts = "T"
-  revision = "c25908fdac501fb53d936ac24f40bf6b6d3fffdc"
+  revision = "6967df2f9740af2bcdbe7311ff61489423a1b51f"
 
 [[projects]]
   branch = "nightly"
-  digest = "1:1d529724345100992b36828cb6b2b19a7d285e260cb45f13e3f6b4175308dc2d"
+  digest = "1:57f5618f3da72a9a6dfdc33bdcf5805dfe371606460428713bfb3a2b54dddf3d"
   name = "github.com/republicprotocol/republic-go"
   packages = [
     "contract",
@@ -337,7 +337,7 @@
     "swarm",
   ]
   pruneopts = "T"
-  revision = "55eee13beb5afa53b765f5ea67eaad0cf7047f38"
+  revision = "66f8f9393bebccd1bef7594fe918a602b17e8dc4"
 
 [[projects]]
   digest = "1:9787d2d3220cbfd444596afd03ab0abcf391df169b789fbe3eae27fa2e426cf6"
@@ -373,7 +373,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ea4a45f31f55c7a42ba3063baa646ac94eb7ee9afe60c1fd2c8b396930222620"
+  digest = "1:9afe5fafd769ebbc8ee7e6cea4606bf2fb2d2841d0571b23d23c77ab57ab96a0"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -390,11 +390,11 @@
     "leveldb/util",
   ]
   pruneopts = "T"
-  revision = "6b91fda63f2e36186f1c9d0e48578defb69c5d43"
+  revision = "353a9fca669c44dedb58d5a074f6d052fb0f58e0"
 
 [[projects]]
   branch = "master"
-  digest = "1:77f54f6503831d121702e88abc62be16dfdba1ac6c5d73cc62ed0c55e130b097"
+  digest = "1:a0097f60e459fbf5512fcc7aa8bf7df60471624dc7956c68e7eb7f8db3706aa7"
   name = "golang.org/x/crypto"
   packages = [
     "blake2s",
@@ -404,11 +404,11 @@
     "sha3",
   ]
   pruneopts = "T"
-  revision = "74cb1d3d52f4c01cbfb44c1b50d204462f3124c7"
+  revision = "e657309f52e71501f9934566ac06dc5c2f7f11a1"
 
 [[projects]]
   branch = "master"
-  digest = "1:0c04b2a25e05e53a014eb3329cd9e3759bee811e333cf6db2ec1819d6c2dad31"
+  digest = "1:a92d7dd2268883d2d466576cb7319cc5321c906d853da4b4ac1ffc407895f809"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -424,18 +424,18 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "9b4f9f5ad5197c79fd623a3638e70d8b26cef344"
+  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
 
 [[projects]]
   branch = "master"
-  digest = "1:d6d9bf31934efd450aeb0a07061dce8a0e84bc80e4aae05841dd588325832a40"
+  digest = "1:aa255b0a0a884e6927587009224910e4758ae91510c03a6bb06bceacc9868c69"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "T"
-  revision = "5cd93ef61a7c8f0f858690154eb6de2e69415fa1"
+  revision = "62eef0e2fa9b2c385f7b2778e763486da6880d37"
 
 [[projects]]
   digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
@@ -474,19 +474,19 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:59a73243379bd5412feb268ec3d9ec0c55acb596ce15fdf937ec29ea6dab441f"
+  digest = "1:077216d94c076b8cd7bd057cb6f7c6d224970cc991bdfe49c0c7a24e8e39ee33"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = "T"
-  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+  revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
   branch = "master"
-  digest = "1:849525811c9f6ae1f5bd9b866adb4c9436f4a12d767f48e33bf343596d4aafd7"
+  digest = "1:212d4045ef941b209a154001718705dc723bd77e0200fcea36d15ec87ed49dec"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "T"
-  revision = "94acd270e44e65579b9ee3cdab25034d33fed608"
+  revision = "b5d43981345bdb2c233eb4bf3277847b48c6fdc6"
 
 [[projects]]
   digest = "1:ef437b2116089e1355b910bcbfb66c90d5164c6623f37deb5b94a6973a1ddf16"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,17 @@
 
 
 [[projects]]
+  digest = "1:777f1f0fc92c6fb838ff214ef3b05160b513c262beb88fa342d7a50e797b9539"
+  name = "github.com/allegro/bigcache"
+  packages = [
+    ".",
+    "queue",
+  ]
+  pruneopts = "T"
+  revision = "f31987a23e44c5121ef8c8b2f2ea2e8ffa37b068"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:c1a6eac1aa52b62daff552d5bd043453a8675b7f9eee0ea924ed7b00a5a56264"
   name = "github.com/aristanetworks/goarista"
@@ -34,7 +45,7 @@
   version = "v1.7.1"
 
 [[projects]]
-  digest = "1:f08158538fb9b5acf86edbf06d0eafd13aafa3277abe534a01f0e99d394e4637"
+  digest = "1:8bf83050739ffd7f13bdc7dd281fccc40718d52eb2ce23fe7d980a3ac1f0a8b0"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -72,16 +83,16 @@
     "trie",
   ]
   pruneopts = "T"
-  revision = "58632d44021bf095b43a1bb2443e6e3690a94739"
-  version = "v1.8.18"
+  revision = "dae82f098570e15d44584f0d7f350713f4774727"
+  version = "v1.8.19"
 
 [[projects]]
-  digest = "1:20e98cc6b7562b472ad307523dd105a0324793a7de09abe9453acefd51821f11"
+  digest = "1:4c183be9fd1680d917006bb4884c1ac3d00a6bd33b0d36c8439c8cbd011e5aac"
   name = "github.com/getsentry/raven-go"
   packages = ["."]
   pruneopts = "T"
-  revision = "3033899c76deb3fb6570d9c4074d00443aeab88f"
-  version = "v0.1.0"
+  revision = "f04e7487e9a6b9d9837d52743fb5f40576c56411"
+  version = "v0.1.1"
 
 [[projects]]
   digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
@@ -294,23 +305,20 @@
   version = "v0.8.0"
 
 [[projects]]
-  branch = "nightly"
-  digest = "1:d4f50500629c3ffcc0e12ff8868e3e32ac80a49e3f00a808840befcf98dbb5ab"
-  name = "github.com/republicprotocol/renex-sdk-go"
-  packages = [
-    ".",
-    "adapter/bindings",
-    "adapter/client",
-    "adapter/funds",
-    "adapter/leveldb",
-    "adapter/orderbook",
-    "adapter/store",
-    "adapter/trader",
-    "core/funds",
-    "core/orderbook",
-  ]
+  branch = "master"
+  digest = "1:2bb44ad552934f1b356396b41030db8e14369a07f326a542512c2a67a423279a"
+  name = "github.com/republicprotocol/beth-go"
+  packages = ["."]
   pruneopts = "T"
-  revision = "6967df2f9740af2bcdbe7311ff61489423a1b51f"
+  revision = "c6cabe0b3e3f9dd71eba66bc90ddb9e535d50324"
+
+[[projects]]
+  branch = "master"
+  digest = "1:9b6c22fe6fba7b56fa465cab0f33a396330421a324c6c48e405ba0885e5275e1"
+  name = "github.com/republicprotocol/renex-swapper-go"
+  packages = ["utils"]
+  pruneopts = "T"
+  revision = "a5eb9459bd40b5c8b5cd59e943239d7b66f7796d"
 
 [[projects]]
   branch = "nightly"
@@ -373,7 +381,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9afe5fafd769ebbc8ee7e6cea4606bf2fb2d2841d0571b23d23c77ab57ab96a0"
+  digest = "1:7b17050757aaa2f52fcc582125d7abaf5fc2ff273bf023da0c4f98e6f2ebed5f"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -390,7 +398,7 @@
     "leveldb/util",
   ]
   pruneopts = "T"
-  revision = "353a9fca669c44dedb58d5a074f6d052fb0f58e0"
+  revision = "b001fa50d6b27f3f0bb175a87d0cb55426d0a0ae"
 
 [[projects]]
   branch = "master"
@@ -404,7 +412,7 @@
     "sha3",
   ]
   pruneopts = "T"
-  revision = "e657309f52e71501f9934566ac06dc5c2f7f11a1"
+  revision = "eb0de9b17e854e9b1ccd9963efafc79862359959"
 
 [[projects]]
   branch = "master"
@@ -428,14 +436,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:aa255b0a0a884e6927587009224910e4758ae91510c03a6bb06bceacc9868c69"
+  digest = "1:a41815681b9cb9d91eb5bd22009d99af713567bb20f14b2ff13765d8fd8de808"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "T"
-  revision = "62eef0e2fa9b2c385f7b2778e763486da6880d37"
+  revision = "4ed8d59d0b35e1e29334a206d1b3f38b1e5dfb31"
 
 [[projects]]
   digest = "1:6164911cb5e94e8d8d5131d646613ff82c14f5a8ce869de2f6d80d9889df8c5a"
@@ -486,7 +494,7 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "T"
-  revision = "b5d43981345bdb2c233eb4bf3277847b48c6fdc6"
+  revision = "31ac5d88444a9e7ad18077db9a165d793ad06a2e"
 
 [[projects]]
   digest = "1:ef437b2116089e1355b910bcbfb66c90d5164c6623f37deb5b94a6973a1ddf16"
@@ -574,7 +582,8 @@
     "github.com/lib/pq",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
-    "github.com/republicprotocol/renex-sdk-go",
+    "github.com/republicprotocol/beth-go",
+    "github.com/republicprotocol/renex-swapper-go/utils",
     "github.com/republicprotocol/republic-go/contract",
     "github.com/republicprotocol/republic-go/crypto",
     "github.com/republicprotocol/republic-go/dispatch",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,10 +11,6 @@
   name = "github.com/republicprotocol/republic-go"
   branch = "nightly"
 
-[[constraint]]
-  name = "github.com/republicprotocol/renex-sdk-go"
-  branch = "nightly"
-
 # Temporary fix https://github.com/golang/dep/issues/1799
 [[override]]
   name = "gopkg.in/fsnotify.v1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,6 +8,10 @@
   version = "1.8.17"
 
 [[constraint]]
+  name = "github.com/republicprotocol/beth-go"
+  branch = "master"
+
+[[constraint]]
   name = "github.com/republicprotocol/republic-go"
   branch = "nightly"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,6 +11,10 @@
   name = "github.com/republicprotocol/republic-go"
   branch = "nightly"
 
+[[constraint]]
+  name = "github.com/republicprotocol/renex-sdk-go"
+  branch = "nightly"
+
 # Temporary fix https://github.com/golang/dep/issues/1799
 [[override]]
   name = "gopkg.in/fsnotify.v1"

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -103,6 +103,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("cannot connect to the database: %v", err)
 	}
+	rewarder, err := ingress.NewRewarder(dbParam)
+	if err != nil {
+		log.Fatalf("cannot connect to the database: %v", err)
+	}
 
 	// New database for persistent storage
 	store, err := leveldb.NewStore(path.Join(os.Getenv("HOME"), "data"), 72*time.Hour, 24*time.Hour)
@@ -123,7 +127,7 @@ func main() {
 	swarmer := swarm.NewSwarmer(swarmClient, store.SwarmMultiAddressStore(), alphaNum, &crypter)
 
 	orderbookClient := grpc.NewOrderbookClient()
-	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, &contractBinder, swarmer, orderbookClient, 4*time.Second, swapper, loginer)
+	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, &contractBinder, swarmer, orderbookClient, 4*time.Second, swapper, loginer, rewarder)
 	ingressAdapter := httpadapter.NewIngressAdapter(ingresser)
 
 	go func() {

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -128,7 +128,7 @@ func main() {
 
 	orderbookClient := grpc.NewOrderbookClient()
 	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, &contractBinder, swarmer, orderbookClient, 4*time.Second, swapper, loginer, rewarder)
-	ingressAdapter, err := httpadapter.NewIngressAdapter(ingresser, config.RenExEthereum.URI, keystore)
+	ingressAdapter, err := httpadapter.NewIngressAdapter(ingresser, contractConn.Config.URI, keystore)
 	if err != nil {
 		log.Fatalf("cannot create ingress adapter: %v", err)
 	}

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -109,7 +109,7 @@ func main() {
 	}
 
 	// New database for persistent storage
-	store, err := leveldb.NewStore(path.Join(os.Getenv("HOME"), "data"), 72*time.Hour, 24*time.Hour)
+	store, err := leveldb.NewStore(path.Join(os.Getenv("HOME"), "data"), 24*time.Hour)
 	if err != nil {
 		log.Fatalf("cannot open leveldb: %v", err)
 	}

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -128,7 +128,7 @@ func main() {
 
 	orderbookClient := grpc.NewOrderbookClient()
 	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, &contractBinder, swarmer, orderbookClient, 4*time.Second, swapper, loginer, rewarder)
-	ingressAdapter := httpadapter.NewIngressAdapter(ingresser, config.RepublicEthereum.Network, keystore)
+	ingressAdapter := httpadapter.NewIngressAdapter(ingresser, config.RenExEthereum.URI, keystore)
 
 	go func() {
 		// Add bootstrap nodes in the store or load from the file.

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -128,7 +128,7 @@ func main() {
 
 	orderbookClient := grpc.NewOrderbookClient()
 	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, &contractBinder, swarmer, orderbookClient, 4*time.Second, swapper, loginer, rewarder)
-	ingressAdapter := httpadapter.NewIngressAdapter(ingresser)
+	ingressAdapter := httpadapter.NewIngressAdapter(ingresser, config.RepublicEthereum.Network, keystore)
 
 	go func() {
 		// Add bootstrap nodes in the store or load from the file.

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -128,7 +128,10 @@ func main() {
 
 	orderbookClient := grpc.NewOrderbookClient()
 	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, &contractBinder, swarmer, orderbookClient, 4*time.Second, swapper, loginer, rewarder)
-	ingressAdapter := httpadapter.NewIngressAdapter(ingresser, config.RenExEthereum.URI, keystore)
+	ingressAdapter, err := httpadapter.NewIngressAdapter(ingresser, config.RenExEthereum.URI, keystore)
+	if err != nil {
+		log.Fatal("cannot create ingress adapter")
+	}
 
 	go func() {
 		// Add bootstrap nodes in the store or load from the file.

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -116,10 +116,10 @@ func main() {
 	defer store.Release()
 	multiAddr.Signature, err = keystore.EcdsaKey.Sign(multiAddr.Hash())
 	if err != nil {
-		log.Fatal("cannot sign own multiAddress")
+		log.Fatalf("cannot sign own multiAddress: %v", err)
 	}
 	if err := store.SwarmMultiAddressStore().InsertMultiAddress(multiAddr); err != nil {
-		log.Fatal("cannot store own multiAddress")
+		log.Fatalf("cannot store own multiAddress: %v", err)
 	}
 
 	crypter := registry.NewCrypter(keystore, &binder, 256, time.Minute)
@@ -130,7 +130,7 @@ func main() {
 	ingresser := ingress.NewIngress(keystore.EcdsaKey, &binder, &contractBinder, swarmer, orderbookClient, 4*time.Second, swapper, loginer, rewarder)
 	ingressAdapter, err := httpadapter.NewIngressAdapter(ingresser, config.RenExEthereum.URI, keystore)
 	if err != nil {
-		log.Fatal("cannot create ingress adapter")
+		log.Fatalf("cannot create ingress adapter: %v", err)
 	}
 
 	go func() {

--- a/contract/binder.go
+++ b/contract/binder.go
@@ -56,7 +56,11 @@ func NewBinder(auth *bind.TransactOpts, conn Conn) (Binder, error) {
 		fmt.Println(fmt.Errorf("cannot bind to RenExBrokerVerifier: %v", err))
 		return Binder{}, err
 	}
-
+	renExSettlement, err := bindings.NewRenExSettlement(common.HexToAddress(conn.Config.RenExSettlementAddress), bind.ContractBackend(conn.Client))
+	if err != nil {
+		fmt.Println(fmt.Errorf("cannot bind to RenExSettlement: %v", err))
+		return Binder{}, err
+	}
 	orderbook, err := bindings.NewOrderbook(common.HexToAddress(conn.Config.OrderbookAddress), bind.ContractBackend(conn.Client))
 	if err != nil {
 		fmt.Println(fmt.Errorf("cannot bind to Orderbook: %v", err))
@@ -76,6 +80,7 @@ func NewBinder(auth *bind.TransactOpts, conn Conn) (Binder, error) {
 		callOpts:     &bind.CallOpts{},
 
 		renExBrokerVerifier: renExBrokerVerifier,
+		renExSettlement:     renExSettlement,
 		orderbook:           orderbook,
 		wyre:                wyre,
 	}, nil

--- a/contract/binder.go
+++ b/contract/binder.go
@@ -8,8 +8,22 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/republicprotocol/renex-ingress-go/contract/bindings"
+	"github.com/republicprotocol/republic-go/order"
 )
+
+type OrderMatch struct {
+	Settled         bool
+	OrderIsBuy      bool
+	MatchedID       [32]byte
+	PriorityVolume  *big.Int
+	SecondaryVolume *big.Int
+	PriorityFee     *big.Int
+	SecondaryFee    *big.Int
+	PriorityToken   uint32
+	SecondaryToken  uint32
+}
 
 // Binder implements all methods that will communicate with the smart contracts
 type Binder struct {
@@ -20,6 +34,8 @@ type Binder struct {
 	callOpts     *bind.CallOpts
 
 	renExBrokerVerifier *bindings.RenExBrokerVerifier
+	renExSettlement     *bindings.RenExSettlement
+	erc20               *bindings.ERC20
 	orderbook           *bindings.Orderbook
 	wyre                *bindings.Wyre
 }
@@ -93,4 +109,13 @@ func (binder *Binder) balanceOf(trader common.Address) (*big.Int, error) {
 // GetOrderTrader of the given order id.
 func (binder *Binder) GetOrderTrader(orderID [32]byte) (common.Address, error) {
 	return binder.orderbook.OrderTrader(&bind.CallOpts{}, orderID)
+}
+
+// GetOrderTrader of the given order id.
+func (binder *Binder) GetMatchDetails(orderID order.ID) (OrderMatch, error) {
+	return binder.renExSettlement.GetMatchDetails(&bind.CallOpts{}, orderID)
+}
+
+func (binder *Binder) Transfer(opts *bind.TransactOpts, to common.Address, value *big.Int) (*types.Transaction, error) {
+	return binder.erc20.Transfer(opts, to, value)
 }

--- a/contract/config.go
+++ b/contract/config.go
@@ -32,6 +32,7 @@ type RenExConfig struct {
 	Network                    Network `json:"network"`
 	URI                        string  `json:"uri"`
 	RenExBrokerVerifierAddress string  `json:"renExBrokerVerifier"`
+	RenExSettlementAddress     string  `json:"renExSettlement"`
 	OrderbookAddress           string  `json:"orderbook"`
 	WyreAddress                string  `json:"wyre"`
 }

--- a/contract/ethereum.go
+++ b/contract/ethereum.go
@@ -35,14 +35,17 @@ func Connect(config RenExConfig) (Conn, error) {
 		switch config.Network {
 		case NetworkMainnet:
 			config.RenExBrokerVerifierAddress = "0x31a0d1a199631d244761eeba67e8501296d2e383"
+			config.RenExSettlementAddress = "0x908262dE0366E42d029B0518D5276762c92B21e1"
 			config.OrderbookAddress = "0x6b8bb175c092de7d81860b18db360b734a2598e0"
 			config.WyreAddress = "0x9f2a7b5e6280727cd6c8486f5f96e5f76164f2df"
 		case NetworkTestnet:
 			config.RenExBrokerVerifierAddress = "0x60fD65ab8db0EdEC2Fc4df254888232e30416f7f"
+			config.RenExSettlementAddress = "0x65A699E555cf93e4e115FfC2DE2F41d5A21DF3Fb"
 			config.OrderbookAddress = "0xA9b453FC64b4766Aab8a867801d0a4eA7b1474E0"
 			config.WyreAddress = "0xB14fA2276D8bD26713A6D98871b2d63Da9eefE6f"
 		case NetworkNightly:
 			config.RenExBrokerVerifierAddress = "0xcf2F6b4b698Cd6a6B3eb1d874a939742d15f8e7E"
+			config.RenExSettlementAddress = "0x5f25233ca99104D31612D4fB937B090d5A2EbB75"
 			config.OrderbookAddress = "0x376127aDc18260fc238eBFB6626b2F4B59eC9b66"
 			config.WyreAddress = "0xB14fA2276D8bD26713A6D98871b2d63Da9eefE6f"
 		case NetworkLocal:

--- a/httpadapter/httpadapter.go
+++ b/httpadapter/httpadapter.go
@@ -515,7 +515,7 @@ func PostRewardsHandler(rewardsAdapter RewardsAdapter) http.HandlerFunc {
 
 		if err := rewardsAdapter.PostRewards(rewards, postRewardsRequest.Info, postRewardsRequest.Signature); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(fmt.Sprintf("failed to save the swap datails: %v", err)))
+			w.Write([]byte(fmt.Sprintf("failed to send rewards: %v", err)))
 			return
 		}
 		w.WriteHeader(http.StatusCreated)

--- a/httpadapter/httpadapter_test.go
+++ b/httpadapter/httpadapter_test.go
@@ -67,8 +67,12 @@ func (adapter *weakAdapter) PostTrader(string) error {
 	return nil
 }
 
-func (adapter *weakAdapter) GetRewards(address string) (map[string]*big.Int, error) {
+func (adapter *weakAdapter) GetRewards(string) (map[string]*big.Int, error) {
 	return nil, nil
+}
+
+func (adapter *weakAdapter) PostRewards(map[string]*big.Int, PostRewardsInfo, string) error {
+	return nil
 }
 
 func (adapter *weakAdapter) GetLogin(string) (int64, string, error) {
@@ -132,6 +136,10 @@ func (adapter *errAdapter) PostTrader(string) error {
 
 func (adapter *errAdapter) GetRewards(address string) (map[string]*big.Int, error) {
 	return nil, errors.New("cannot get rewards")
+}
+
+func (adapter *errAdapter) PostRewards(map[string]*big.Int, PostRewardsInfo, string) error {
+	return errors.New("cannot post rewards")
 }
 
 func (adapter *errAdapter) GetLogin(string) (int64, string, error) {

--- a/httpadapter/httpadapter_test.go
+++ b/httpadapter/httpadapter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -66,6 +67,10 @@ func (adapter *weakAdapter) PostTrader(string) error {
 	return nil
 }
 
+func (adapter *weakAdapter) GetRewards(address string) (map[string]*big.Int, error) {
+	return nil, nil
+}
+
 func (adapter *weakAdapter) GetLogin(string) (int64, string, error) {
 	return 0, "", nil
 }
@@ -123,6 +128,10 @@ func (adapter *errAdapter) GetTrader(string) (string, error) {
 
 func (adapter *errAdapter) PostTrader(string) error {
 	return errors.New("cannot post trader")
+}
+
+func (adapter *errAdapter) GetRewards(address string) (map[string]*big.Int, error) {
+	return nil, errors.New("cannot get rewards")
 }
 
 func (adapter *errAdapter) GetLogin(string) (int64, string, error) {

--- a/httpadapter/ingress.go
+++ b/httpadapter/ingress.go
@@ -365,7 +365,9 @@ func (adapter *ingressAdapter) PostRewards(rewards map[string]*big.Int, info Pos
 	defer cancel()
 	if token == order.TokenETH {
 		if err := adapter.Account.Transfer(ctx, common.HexToAddress(info.Address), amount, 1); err != nil { // TODO: Subtract transaction fee from amount
-			// TODO: Remove from table
+			if err := adapter.DeleteWithdrawalDetails(hash); err != nil {
+				return err
+			}
 			return err
 		}
 	} else {
@@ -373,7 +375,9 @@ func (adapter *ingressAdapter) PostRewards(rewards map[string]*big.Int, info Pos
 			return adapter.Ingress.TransferERC20(transactOpts, common.HexToAddress(info.Address), info.Token, amount)
 		}
 		if err := adapter.Account.Transact(ctx, nil, txFunc, nil, 1); err != nil {
-			// TODO: Remove from table
+			if err := adapter.DeleteWithdrawalDetails(hash); err != nil {
+				return err
+			}
 			return err
 		}
 	}

--- a/httpadapter/ingress.go
+++ b/httpadapter/ingress.go
@@ -319,7 +319,11 @@ func (adapter *ingressAdapter) getRewards(ren renex.RenEx, address string, divis
 			token = order.Token(orderMatch.SecondaryToken).String()
 			newReward = new(big.Int).Div(orderMatch.SecondaryFee, divisor)
 		}
-		rewards[token] = new(big.Int).Add(rewards[token], newReward)
+		if _, ok := rewards[token]; ok {
+			rewards[token] = new(big.Int).Add(rewards[token], newReward)
+		} else {
+			rewards[token] = newReward
+		}
 	}
 	return rewards, nil
 }

--- a/httpadapter/ingress.go
+++ b/httpadapter/ingress.go
@@ -261,7 +261,7 @@ func (adapter *ingressAdapter) GetRewards(address string) (map[string]*big.Int, 
 	if err != nil {
 		return nil, err
 	}
-	ren, err := renex.NewRenExWithPrivKey("mainnet", privKey)
+	ren, err := renex.NewRenExWithPrivKey("testnet", privKey) // TODO: Use mainnet
 	if err != nil {
 		return nil, err
 	}

--- a/httpadapter/ingress.go
+++ b/httpadapter/ingress.go
@@ -347,7 +347,24 @@ func (adapter *ingressAdapter) PostRewards(rewards map[string]*big.Int, info Pos
 		return ErrUnauthorizedAddress
 	}
 
-	if err := adapter.InsertWithdrawalDetails(rewards, hash, info.Address, info.Token, info.Amount, info.Nonce); err != nil {
+	var token order.Token
+	switch info.Token {
+	case "BTC":
+		token = 0
+	case "ETH":
+		token = 1
+	case "DGX":
+		token = 256
+	case "TUSD":
+		token = 257
+	case "REN":
+		token = 65536
+	case "ZRX":
+		token = 65537
+	case "OMG":
+		token = 65538
+	}
+	if err := adapter.InsertWithdrawalDetails(rewards, hash, info.Address, token, info.Amount, info.Nonce); err != nil {
 		return err
 	}
 
@@ -357,7 +374,7 @@ func (adapter *ingressAdapter) PostRewards(rewards map[string]*big.Int, info Pos
 		return err
 	}
 
-	if err := ren.Transfer(info.Address, info.Token, info.Amount); err != nil { // TODO: Subtract transaction fee from amount
+	if err := ren.Transfer(info.Address, token, info.Amount); err != nil { // TODO: Subtract transaction fee from amount
 		// TODO: Remove from table
 		return err
 	}

--- a/httpadapter/ingress.go
+++ b/httpadapter/ingress.go
@@ -284,8 +284,12 @@ func (adapter *ingressAdapter) GetRewards(address string) (map[string]*big.Int, 
 		if err != nil {
 			return nil, err
 		}
-		for key, value := range referralRewards {
-			rewards[key] = new(big.Int).Add(rewards[key], value)
+		for token, amount := range referralRewards {
+			if _, ok := rewards[token]; ok {
+				rewards[token] = new(big.Int).Add(rewards[token], amount)
+			} else {
+				rewards[token] = amount
+			}
 		}
 	}
 

--- a/httpadapter/ingress.go
+++ b/httpadapter/ingress.go
@@ -56,6 +56,8 @@ var ErrUnauthorizedAddress = errors.New("unauthorized address")
 
 var ErrInvalidAmount = errors.New("invalid amount")
 
+var ErrUnsupportedToken = errors.New("unsupported token")
+
 // An OpenOrderAdapter can be used to open an order.Order by sending an
 // OrderFragmentMapping to the Darknodes in the network.
 type OpenOrderAdapter interface {
@@ -350,22 +352,9 @@ func (adapter *ingressAdapter) PostRewards(rewards map[string]*big.Int, info Pos
 		return ErrUnauthorizedAddress
 	}
 
-	var token order.Token
-	switch info.Token {
-	case "BTC":
-		token = 0
-	case "ETH":
-		token = 1
-	case "DGX":
-		token = 256
-	case "TUSD":
-		token = 257
-	case "REN":
-		token = 65536
-	case "ZRX":
-		token = 65537
-	case "OMG":
-		token = 65538
+	token, err := getTokenCode(info.Token)
+	if err != nil {
+		return err
 	}
 	amount := new(big.Int)
 	amount, ok := amount.SetString(info.Amount, 10)
@@ -388,6 +377,29 @@ func (adapter *ingressAdapter) PostRewards(rewards map[string]*big.Int, info Pos
 	}
 
 	return nil
+}
+
+func getTokenCode(token string) (order.Token, error) {
+	var tokenCode order.Token
+	switch token {
+	case "BTC":
+		tokenCode = order.TokenBTC
+	case "ETH":
+		tokenCode = order.TokenETH
+	case "DGX":
+		tokenCode = order.TokenDGX
+	case "TUSD":
+		tokenCode = order.TokenTUSD
+	case "REN":
+		tokenCode = order.TokenREN
+	case "ZRX":
+		tokenCode = order.TokenZRX
+	case "OMG":
+		tokenCode = order.TokenOMG
+	default:
+		return 0, ErrUnsupportedToken
+	}
+	return tokenCode, nil
 }
 
 func (adapter *ingressAdapter) GetLogin(address string) (int64, string, error) {

--- a/httpadapter/ingress.go
+++ b/httpadapter/ingress.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
@@ -345,7 +346,7 @@ func (adapter *ingressAdapter) PostRewards(rewards map[string]*big.Int, info Pos
 		return err
 	}
 	address := ethCrypto.PubkeyToAddress(*publicKey)
-	if info.Address != address.String() {
+	if info.Address != strings.ToLower(address.String()) {
 		return ErrUnauthorizedAddress
 	}
 

--- a/httpadapter/ingress_test.go
+++ b/httpadapter/ingress_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Ingress Adapter", func() {
 	Context("when opening orders", func() {
 
 		It("should forward data to the ingress if the signature and mapping are well formed", func() {
-			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, 0, 0}
+			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
 			ingressAdapter := NewIngressAdapter(ingress)
 
 			traderBytes := [20]byte{}
@@ -182,7 +182,7 @@ var _ = Describe("Ingress Adapter", func() {
 		})
 
 		It("should not call ingress.OpenOrder if trader is invalid", func() {
-			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, 0, 0}
+			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
 			ingressAdapter := NewIngressAdapter(ingress)
 			traderBytes := []byte{}
 			copy(traderBytes[:], "incorrect trader")
@@ -198,7 +198,7 @@ var _ = Describe("Ingress Adapter", func() {
 		})
 
 		It("should not call ingress.OpenOrder if pool hash is invalid", func() {
-			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, 0, 0}
+			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
 			ingressAdapter := NewIngressAdapter(ingress)
 			traderBytes := [20]byte{}
 			_, err := rand.Read(traderBytes[:])
@@ -219,7 +219,7 @@ var _ = Describe("Ingress Adapter", func() {
 	Context("when approving withdrawals", func() {
 
 		It("should forward data to the ingress if the signature and mapping are well formed", func() {
-			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, 0, 0}
+			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
 			ingressAdapter := NewIngressAdapter(ingress)
 
 			traderBytes := [20]byte{}
@@ -233,7 +233,7 @@ var _ = Describe("Ingress Adapter", func() {
 		})
 
 		It("should not call ingress.ApproveWithdrawal if trader is invalid", func() {
-			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, 0, 0}
+			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
 			ingressAdapter := NewIngressAdapter(ingress)
 			traderBytes := []byte{}
 			copy(traderBytes[:], "incorrect trader")
@@ -287,9 +287,17 @@ func (loginer *mockLoginer) UpdateLogin(address string, kyberUID int64, kycType 
 	return nil
 }
 
+type mockRewarder struct {
+}
+
+func (ingress *mockRewarder) SelectReferrents(address string) ([]string, error) {
+	return nil, nil
+}
+
 type mockIngress struct {
 	ingress.Swapper
 	ingress.Loginer
+	ingress.Rewarder
 	numOpened    int64
 	numWithdrawn int64
 }

--- a/httpadapter/ingress_test.go
+++ b/httpadapter/ingress_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
+	"math/big"
 	mathRand "math/rand"
 	"sync/atomic"
 	"time"
@@ -12,8 +13,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/republicprotocol/renex-ingress-go/httpadapter"
-
 	"github.com/republicprotocol/renex-ingress-go/ingress"
+	"github.com/republicprotocol/republic-go/contract"
 	"github.com/republicprotocol/republic-go/crypto"
 	"github.com/republicprotocol/republic-go/order"
 )
@@ -164,7 +165,7 @@ var _ = Describe("Ingress Adapter", func() {
 
 		It("should forward data to the ingress if the signature and mapping are well formed", func() {
 			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
-			ingressAdapter := NewIngressAdapter(ingress)
+			ingressAdapter := NewIngressAdapter(ingress, contract.NetworkTestnet, crypto.Keystore{})
 
 			traderBytes := [20]byte{}
 			_, err := rand.Read(traderBytes[:])
@@ -183,7 +184,7 @@ var _ = Describe("Ingress Adapter", func() {
 
 		It("should not call ingress.OpenOrder if trader is invalid", func() {
 			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
-			ingressAdapter := NewIngressAdapter(ingress)
+			ingressAdapter := NewIngressAdapter(ingress, contract.NetworkTestnet, crypto.Keystore{})
 			traderBytes := []byte{}
 			copy(traderBytes[:], "incorrect trader")
 			orderFragmentMappingIn := OrderFragmentMapping{}
@@ -199,7 +200,7 @@ var _ = Describe("Ingress Adapter", func() {
 
 		It("should not call ingress.OpenOrder if pool hash is invalid", func() {
 			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
-			ingressAdapter := NewIngressAdapter(ingress)
+			ingressAdapter := NewIngressAdapter(ingress, contract.NetworkTestnet, crypto.Keystore{})
 			traderBytes := [20]byte{}
 			_, err := rand.Read(traderBytes[:])
 			Expect(err).ShouldNot(HaveOccurred())
@@ -220,7 +221,7 @@ var _ = Describe("Ingress Adapter", func() {
 
 		It("should forward data to the ingress if the signature and mapping are well formed", func() {
 			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
-			ingressAdapter := NewIngressAdapter(ingress)
+			ingressAdapter := NewIngressAdapter(ingress, contract.NetworkTestnet, crypto.Keystore{})
 
 			traderBytes := [20]byte{}
 			_, err := rand.Read(traderBytes[:])
@@ -234,7 +235,7 @@ var _ = Describe("Ingress Adapter", func() {
 
 		It("should not call ingress.ApproveWithdrawal if trader is invalid", func() {
 			ingress := &mockIngress{&mockSwapper{}, &mockLoginer{}, &mockRewarder{}, 0, 0}
-			ingressAdapter := NewIngressAdapter(ingress)
+			ingressAdapter := NewIngressAdapter(ingress, contract.NetworkTestnet, crypto.Keystore{})
 			traderBytes := []byte{}
 			copy(traderBytes[:], "incorrect trader")
 
@@ -292,6 +293,10 @@ type mockRewarder struct {
 
 func (ingress *mockRewarder) SelectReferrents(address string) ([]string, error) {
 	return nil, nil
+}
+
+func (ingress *mockRewarder) InsertWithdrawalDetails(rewards map[string]*big.Int, hash []byte, address string, token order.Token, amount *big.Int, nonce int64) error {
+	return nil
 }
 
 type mockIngress struct {

--- a/httpadapter/marshal.go
+++ b/httpadapter/marshal.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/republicprotocol/renex-ingress-go/ingress"
@@ -92,6 +93,18 @@ type PostAuthorizeRequest struct {
 type GetAuthorizeResponse struct {
 	AtomAddress string `json:"atomAddress"`
 	Status      bool   `json:"status"`
+}
+
+type PostRewardsInfo struct {
+	Address string      `json:"address"`
+	Token   order.Token `json:"token"`
+	Amount  *big.Int    `json:"amount"`
+	Nonce   int64       `json:"nonce"`
+}
+
+type PostRewardsRequest struct {
+	Info      PostRewardsInfo `json:"info"`
+	Signature string          `json:"signature"`
 }
 
 func MarshalSignature(signatureIn [65]byte) string {

--- a/httpadapter/marshal.go
+++ b/httpadapter/marshal.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/republicprotocol/renex-ingress-go/ingress"
@@ -96,10 +95,10 @@ type GetAuthorizeResponse struct {
 }
 
 type PostRewardsInfo struct {
-	Address string   `json:"address"`
-	Token   string   `json:"token"`
-	Amount  *big.Int `json:"amount"`
-	Nonce   int64    `json:"nonce"`
+	Address string `json:"address"`
+	Token   string `json:"token"`
+	Amount  string `json:"amount"`
+	Nonce   int64  `json:"nonce"`
 }
 
 type PostRewardsRequest struct {

--- a/httpadapter/marshal.go
+++ b/httpadapter/marshal.go
@@ -96,10 +96,10 @@ type GetAuthorizeResponse struct {
 }
 
 type PostRewardsInfo struct {
-	Address string      `json:"address"`
-	Token   order.Token `json:"token"`
-	Amount  *big.Int    `json:"amount"`
-	Nonce   int64       `json:"nonce"`
+	Address string   `json:"address"`
+	Token   string   `json:"token"`
+	Amount  *big.Int `json:"amount"`
+	Nonce   int64    `json:"nonce"`
 }
 
 type PostRewardsRequest struct {

--- a/ingress/contract.go
+++ b/ingress/contract.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	beth "github.com/republicprotocol/beth-go"
 	"github.com/republicprotocol/renex-ingress-go/contract"
 	"github.com/republicprotocol/republic-go/order"
 	"github.com/republicprotocol/republic-go/registry"
@@ -32,7 +33,7 @@ type ContractBinder interface {
 }
 
 type RenExContractBinder interface {
-	Transfer(opts *bind.TransactOpts, to common.Address, value *big.Int) (*types.Transaction, error)
+	Transfer(opts *bind.TransactOpts, account beth.Account, to common.Address, tokenSymbol string, value *big.Int) (*types.Transaction, error)
 
 	GetOrderTrader(orderID [32]byte) (common.Address, error)
 

--- a/ingress/contract.go
+++ b/ingress/contract.go
@@ -26,18 +26,18 @@ type ContractBinder interface {
 
 	PreviousPods() ([]registry.Pod, error)
 
+	Orders(offset, limit int) ([]order.ID, []order.Status, []string, error)
+
+	OrderCounts() (uint64, error)
+}
+
+type RenExContractBinder interface {
+	Transfer(opts *bind.TransactOpts, to common.Address, value *big.Int) (*types.Transaction, error)
+
 	GetOrderTrader(orderID [32]byte) (common.Address, error)
 
 	GetMatchDetails(orderID order.ID) (contract.OrderMatch, error)
 
-	Orders(offset, limit int) ([]order.ID, []order.Status, []string, error)
-
-	OrderCounts() (uint64, error)
-
-	Transfer(opts *bind.TransactOpts, to common.Address, value *big.Int) (*types.Transaction, error)
-}
-
-type RenExContractBinder interface {
 	GetTraderWithdrawalNonce(trader common.Address) (*big.Int, error)
 
 	// Wyre KYC

--- a/ingress/contract.go
+++ b/ingress/contract.go
@@ -3,7 +3,11 @@ package ingress
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/republicprotocol/renex-ingress-go/contract"
+	"github.com/republicprotocol/republic-go/order"
 	"github.com/republicprotocol/republic-go/registry"
 )
 
@@ -21,6 +25,16 @@ type ContractBinder interface {
 	Pods() ([]registry.Pod, error)
 
 	PreviousPods() ([]registry.Pod, error)
+
+	GetOrderTrader(orderID [32]byte) (common.Address, error)
+
+	GetMatchDetails(orderID order.ID) (contract.OrderMatch, error)
+
+	Orders(offset, limit int) ([]order.ID, []order.Status, []string, error)
+
+	OrderCounts() (uint64, error)
+
+	Transfer(opts *bind.TransactOpts, to common.Address, value *big.Int) (*types.Transaction, error)
 }
 
 type RenExContractBinder interface {
@@ -28,6 +42,4 @@ type RenExContractBinder interface {
 
 	// Wyre KYC
 	BalanceOf(common.Address) (*big.Int, error)
-
-	GetOrderTrader(orderID [32]byte) (common.Address, error)
 }

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -101,8 +101,11 @@ type Ingress interface {
 	// Swapper interface implements atomic swapper network functions.
 	Swapper
 
-	// Loginer interface implements login database interaction functions.
+	// Loginer interface implements traders database interaction functions.
 	Loginer
+
+	// Rewarder interface implements rewards database interaction functions.
+	Rewarder
 }
 
 type ingress struct {
@@ -120,12 +123,13 @@ type ingress struct {
 	queueRequests chan Request
 	Swapper
 	Loginer
+	Rewarder
 }
 
 // NewIngress returns an Ingress. The background services of the Ingress must
 // be started separately by calling Ingress.OpenOrderProcess and
 // Ingress.OpenOrderFragmentsProcess.
-func NewIngress(ecdsaKey crypto.EcdsaKey, contract ContractBinder, renExContract RenExContractBinder, swarmer swarm.Swarmer, orderbookClient orderbook.Client, epochPollInterval time.Duration, swapper Swapper, loginer Loginer) Ingress {
+func NewIngress(ecdsaKey crypto.EcdsaKey, contract ContractBinder, renExContract RenExContractBinder, swarmer swarm.Swarmer, orderbookClient orderbook.Client, epochPollInterval time.Duration, swapper Swapper, loginer Loginer, rewarder Rewarder) Ingress {
 	ingress := &ingress{
 		ecdsaKey:          ecdsaKey,
 		contract:          contract,

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -614,11 +614,11 @@ func (ingress *ingress) orderParityFromOrderFragmentMappings(orderFragmentMappin
 }
 
 func (ingress *ingress) OrderTrader(orderID [32]byte) (common.Address, error) {
-	return ingress.contract.GetOrderTrader(orderID)
+	return ingress.renExContract.GetOrderTrader(orderID)
 }
 
 func (ingress *ingress) MatchDetails(orderID order.ID) (contract.OrderMatch, error) {
-	return ingress.contract.GetMatchDetails(orderID)
+	return ingress.renExContract.GetMatchDetails(orderID)
 }
 
 func (ingress *ingress) ListOrders() ([]order.ID, []order.Status, []string, error) {
@@ -668,5 +668,5 @@ func (ingress *ingress) ListOrdersByTrader(traderAddress string) ([]order.ID, er
 }
 
 func (ingress *ingress) TransferERC20(transactOpts *bind.TransactOpts, address common.Address, amount *big.Int) (*types.Transaction, error) {
-	return ingress.contract.Transfer(transactOpts, address, amount)
+	return ingress.renExContract.Transfer(transactOpts, address, amount)
 }

--- a/ingress/ingress.go
+++ b/ingress/ingress.go
@@ -137,6 +137,7 @@ func NewIngress(ecdsaKey crypto.EcdsaKey, contract ContractBinder, renExContract
 		swarmer:           swarmer,
 		Swapper:           swapper,
 		Loginer:           loginer,
+		Rewarder:          rewarder,
 		orderbookClient:   orderbookClient,
 		epochPollInterval: epochPollInterval,
 

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -520,3 +520,7 @@ type mockRewarder struct {
 func (rewarder *mockRewarder) SelectReferrents(address string) ([]string, error) {
 	return nil, nil
 }
+
+func (rewarder *mockRewarder) InsertWithdrawalDetails(rewards map[string]*big.Int, hash []byte, address string, token order.Token, amount *big.Int, nonce int64) error {
+	return nil
+}

--- a/ingress/ingress_test.go
+++ b/ingress/ingress_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Ingress", func() {
 		swarmer := mockSwarmer{}
 		orderbookClient := mockOrderbookClient{}
 
-		ingress = NewIngress(ecdsaKey, contract, renExContract, &swarmer, &orderbookClient, time.Millisecond, &mockSwapper{}, &mockLoginer{})
+		ingress = NewIngress(ecdsaKey, contract, renExContract, &swarmer, &orderbookClient, time.Millisecond, &mockSwapper{}, &mockLoginer{}, &mockRewarder{})
 		errChSync = ingress.Sync(done)
 		errChProcess = ingress.ProcessRequests(done)
 
@@ -502,14 +502,21 @@ func (swapper *mockSwapper) InsertSwapDetails(orderID string, swapDetails string
 type mockLoginer struct {
 }
 
-func (Loginer *mockLoginer) SelectLogin(address string) (int64, string, error) {
+func (loginer *mockLoginer) SelectLogin(address string) (int64, string, error) {
 	return 0, "", nil
 }
 
-func (Loginer *mockLoginer) InsertLogin(address, referrer string) error {
+func (loginer *mockLoginer) InsertLogin(address, referrer string) error {
 	return nil
 }
 
-func (Loginer *mockLoginer) UpdateLogin(address string, kyberUID int64, kycType int) error {
+func (loginer *mockLoginer) UpdateLogin(address string, kyberUID int64, kycType int) error {
 	return nil
+}
+
+type mockRewarder struct {
+}
+
+func (rewarder *mockRewarder) SelectReferrents(address string) ([]string, error) {
+	return nil, nil
 }

--- a/ingress/loginer.go
+++ b/ingress/loginer.go
@@ -50,7 +50,8 @@ func (loginer *loginer) SelectLogin(address string) (int64, string, error) {
 }
 
 func (loginer *loginer) InsertLogin(address, referrer string) error {
-	if err := loginer.QueryRow("SELECT * FROM traders WHERE referrer=$1", strings.ToLower(referrer)).Scan(nil); err != nil {
+	var tmp sql.NullString
+	if err := loginer.QueryRow("SELECT address FROM traders WHERE referrer=$1", strings.ToLower(referrer)).Scan(tmp); err != nil {
 		if err != sql.ErrNoRows {
 			return err
 		}

--- a/ingress/loginer.go
+++ b/ingress/loginer.go
@@ -51,7 +51,7 @@ func (loginer *loginer) SelectLogin(address string) (int64, string, error) {
 
 func (loginer *loginer) InsertLogin(address, referrer string) error {
 	var tmp sql.NullString
-	if err := loginer.QueryRow("SELECT address FROM traders WHERE referrer=$1", strings.ToLower(referrer)).Scan(tmp); err != nil {
+	if err := loginer.QueryRow("SELECT address FROM traders WHERE referrer=$1", strings.ToLower(referrer)).Scan(&tmp); err != nil {
 		if err != sql.ErrNoRows {
 			return err
 		}

--- a/ingress/loginer.go
+++ b/ingress/loginer.go
@@ -50,6 +50,12 @@ func (loginer *loginer) SelectLogin(address string) (int64, string, error) {
 }
 
 func (loginer *loginer) InsertLogin(address, referrer string) error {
+	if err := loginer.QueryRow("SELECT * FROM traders WHERE referrer=$1", strings.ToLower(referrer)).Scan(nil); err != nil {
+		if err != sql.ErrNoRows {
+			return err
+		}
+		referrer = "" // User has input a non-existent referral code so we do not store it
+	}
 	timestamp := time.Now().Unix()
 	_, err := loginer.Exec("INSERT INTO traders (address, referrer, referral_code, created_at) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING", strings.ToLower(address), strings.ToLower(referrer), uuid.NewV4().String(), timestamp)
 	return err

--- a/ingress/rewarder.go
+++ b/ingress/rewarder.go
@@ -76,12 +76,12 @@ func (rewarder *rewarder) InsertWithdrawalDetails(rewards map[string]*big.Int, h
 		if err := rows.Scan(&sqlAmount); err != nil {
 			return err
 		}
-		rewards[tokenSymbol] = new(big.Int).Add(rewards[tokenSymbol], sqlAmount)
+		rewards[tokenSymbol] = new(big.Int).Sub(rewards[tokenSymbol], sqlAmount)
 	}
 	if err := rows.Err(); err != nil {
 		return err
 	}
-	if amount.Cmp(rewards[tokenSymbol]) != 1 {
+	if amount.Cmp(rewards[tokenSymbol]) == 1 {
 		return ErrInsufficientFunds
 	}
 

--- a/ingress/rewarder.go
+++ b/ingress/rewarder.go
@@ -17,6 +17,7 @@ var ErrInsufficientFunds = errors.New("insufficient funds")
 type Rewarder interface {
 	SelectReferrents(address string) ([]string, error)
 	InsertWithdrawalDetails(rewards map[string]*big.Int, hash []byte, address string, token order.Token, amount *big.Int, nonce int64) error
+	DeleteWithdrawalDetails(hash []byte) error
 }
 
 type rewarder struct {
@@ -107,5 +108,10 @@ func (rewarder *rewarder) InsertWithdrawalDetails(rewards map[string]*big.Int, h
 
 	timestamp := time.Now().Unix()
 	_, err = rewarder.Exec("INSERT INTO withdrawals (hash, address, token, amount, timestamp, nonce) VALUES ($1, $2, $3, $4, $5, $6)", hash, strings.ToLower(address), token, amount.String(), timestamp, nonce)
+	return err
+}
+
+func (rewarder *rewarder) DeleteWithdrawalDetails(hash []byte) error {
+	_, err := rewarder.Exec("DELETE FROM withdrawals WHERE hash=$1", hash)
 	return err
 }

--- a/ingress/rewarder.go
+++ b/ingress/rewarder.go
@@ -87,7 +87,7 @@ func (rewarder *rewarder) InsertWithdrawalDetails(rewards map[string]*big.Int, h
 
 	// Ensure nonce is valid
 	var sqlNonce sql.NullInt64
-	if err := rewarder.QueryRow("SELECT nonce FROM withdrawals ORDER BY nonce DESC WHERE address=$1", strings.ToLower(address)).Scan(&nonce); err != nil {
+	if err := rewarder.QueryRow("SELECT nonce FROM withdrawals WHERE address=$1 ORDER BY nonce DESC", strings.ToLower(address)).Scan(&nonce); err != nil {
 		if err != sql.ErrNoRows {
 			return err
 		}

--- a/ingress/rewarder.go
+++ b/ingress/rewarder.go
@@ -106,6 +106,6 @@ func (rewarder *rewarder) InsertWithdrawalDetails(rewards map[string]*big.Int, h
 	}
 
 	timestamp := time.Now().Unix()
-	_, err = rewarder.Exec("INSERT INTO withdrawals (hash, address, token, amount, timestamp, nonce) VALUES ($1, $2, $3, $4, $5, $6)", hash, strings.ToLower(address), tokenSymbol, amount.String(), timestamp, nonce)
+	_, err = rewarder.Exec("INSERT INTO withdrawals (hash, address, token, amount, timestamp, nonce) VALUES ($1, $2, $3, $4, $5, $6)", hash, strings.ToLower(address), token, amount.String(), timestamp, nonce)
 	return err
 }

--- a/ingress/rewarder.go
+++ b/ingress/rewarder.go
@@ -1,0 +1,58 @@
+package ingress
+
+import (
+	"database/sql"
+	"strings"
+
+	_ "github.com/lib/pq"
+)
+
+type Rewarder interface {
+	SelectReferrents(address string) ([]string, error)
+}
+
+type rewarder struct {
+	*sql.DB
+}
+
+func NewRewarder(databaseURL string) (Rewarder, error) {
+	db, err := sql.Open("postgres", databaseURL)
+	return &rewarder{
+		db,
+	}, err
+}
+
+func (rewarder *rewarder) SelectReferrents(address string) ([]string, error) {
+	// Select traders referral code
+	var sqlReferrer sql.NullString
+	if err := rewarder.QueryRow("SELECT referral_code FROM traders WHERE address=$1", strings.ToLower(address)).Scan(&sqlReferrer); err != nil {
+		return nil, err
+	}
+	var referrer string
+	if sqlReferrer.Valid {
+		referrer = sqlReferrer.String
+	}
+
+	// Find traders that are using this code
+	rows, err := rewarder.Query("SELECT address FROM traders WHERE referrer=$1", referrer)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var referrents []string
+	for rows.Next() {
+		var sqlReferrent sql.NullString
+		err = rows.Scan(&sqlReferrent)
+		if err != nil {
+			return nil, err
+		}
+		if sqlReferrent.Valid {
+			referrents = append(referrents, sqlReferrent.String)
+		}
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+	return referrents, nil
+}


### PR DESCRIPTION
**Description**

Running the User Referral Program requires us to track the fees paid by referent users. From these fees, some portion needs to be kept as a rebate for the referent, as well as the referrer.

To do this, we need to be able to query how much we owe, as rebate, to a referent / referrer. After a withdrawal has been made, we must also validate the amount that has been paid out to a referent / referrer so that they cannot "double withdraw".

**Design**

We expose a `GET` endpoint at `/rewards/{address}` where a trader can find the amount they have received in total (note: this does not keep track of withdrawals). The `POST` endpoint at `/rewards` allows users to submit withdrawal requests. This request consists of the following object:

```json
{
	"info": {
		"address": "0x...",
		"token": "ETH",
		"amount": "50000000000000",
		"nonce": 1
	},
	"signature": "pI3iSCR..."
}
```

> Note: the signature is a signed hash of the info struct

To keep track of a users past withdrawals, we create a database table called `withdrawals`, which is made up of the following fields:

| hash | address | token | amount | timestamp | nonce |
| --- | --- | --- | --- | --- | --- |
| `\x8b8dcb...` | `0x...` | 1 | 50000000000000 | 1543539235 | 1 |

When a user submits a `POST` request, we calculate their total balance and deduct any past withdrawals. This can be improved in future for performance reasons.

**Unresolved Issues**

Currently withdrawals requests are handled automatically by the Ingress, so if a user submits a `POST` request and it is valid, the Ingress transfers money to the trader directly. We want to make this a manual process so that the amounts be verified by a human before the transaction is made. This helps to maintain the security of funds held by RenEx.